### PR TITLE
fix: add the missing config of proxy in gitalk

### DIFF
--- a/layouts/partials/comment.html
+++ b/layouts/partials/comment.html
@@ -25,6 +25,9 @@
             {{- $source := $cdn.gitalkJS | default "lib/gitalk/gitalk.min.js" -}}
             {{- dict "Source" $source "Fingerprint" $fingerprint | dict "Scratch" .Scratch "Data" | partial "scratch/script.html" -}}
             {{- $commentConfig = dict "id" .Date "title" .Title "clientID" $gitalk.clientId "clientSecret" $gitalk.clientSecret "repo" $gitalk.repo "owner" $gitalk.owner "admin" (slice $gitalk.owner) | dict "gitalk" | merge $commentConfig -}}
+            {{- with $gitalk.proxy -}}
+                {{- $commentConfig = dict "proxy" . | dict "gitalk" | merge $commentConfig -}}
+            {{- end -}}
             <noscript>
                 Please enable JavaScript to view the comments powered by <a href="https://github.com/gitalk/gitalk"></a>Gitalk</a>.
             </noscript>


### PR DESCRIPTION
sometimes i need change oauth proxy, so i add those lines.

thanks!