### PR TITLE
fix site.webmanifest 404

### DIFF
--- a/layouts/partials/head/link.html
+++ b/layouts/partials/head/link.html
@@ -13,7 +13,9 @@
     {{- with .Site.Params.app.iconColor -}}
         <link rel="mask-icon" href="/safari-pinned-tab.svg" color="{{ . }}">
     {{- end -}}
-    <link rel="manifest" href="/site.webmanifest">
+    {{- if eq .Site.Params.enablePWA true -}}
+        <link rel="manifest" href="/site.webmanifest">
+    {{- end -}}
 {{- end -}}
 
 <link rel="canonical" href="{{ .Permalink }}" />


### PR DESCRIPTION
when params.enablePWA is not true, there will be a 404 error for this file in browser console.