### PR TITLE
[Feat] Add Linktree link support

### DIFF
--- a/assets/data/social.yml
+++ b/assets/data/social.yml
@@ -525,7 +525,15 @@ buymeacoffee:
   Icon:
     Simpleicons: buymeacoffee
 
-# 067: Email
+# 067: Linktree
+linktree:
+  Weight: 65
+  Prefix: https://linktr.ee/
+  Title: Linktree
+  Icon:
+    Simpleicons: linktree
+
+# 068: Email
 email:
   Weight: 67
   Template: mailto:%v
@@ -533,7 +541,7 @@ email:
   Icon:
     Class: far fa-envelope fa-fw
 
-# 068: RSS
+# 069: RSS
 rss:
   Weight: 68
   Url: /index.xml

--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -249,6 +249,7 @@ enableEmoji = true
         Liberapay = "xxx"
         Ko-Fi = "xxx"
         BuyMeACoffee = ""
+        Linktree = ""
         Email = "xxxx@xxxx.com"
         RSS = true
         [languages.en.params.social.Mastodon]
@@ -479,6 +480,7 @@ enableEmoji = true
         Liberapay = ""
         Ko-Fi = ""
         BuyMeACoffee = ""
+        Linktree = ""
         Email = "xxxx@xxxx.com"
         RSS = true
 

--- a/exampleSite/content/posts/theme-documentation-basics/index.en.md
+++ b/exampleSite/content/posts/theme-documentation-basics/index.en.md
@@ -416,6 +416,7 @@ Please open the code block below to view the complete sample configuration :(far
     Liberapay = ""
     Ko-Fi = ""
     BuyMeACoffee = ""
+    Linktree = ""
     Email = "xxxx@xxxx.com"
     RSS = true # {{< version 0.2.0 >}}
 

--- a/exampleSite/content/posts/theme-documentation-basics/index.zh-cn.md
+++ b/exampleSite/content/posts/theme-documentation-basics/index.zh-cn.md
@@ -420,6 +420,7 @@ hugo
     Liberapay = ""
     Ko-Fi = ""
     BuyMeACoffee = ""
+    Linktree = ""
     Email = "xxxx@xxxx.com"
     RSS = true # {{< version 0.2.0 >}}
 


### PR DESCRIPTION
[Linktree](https://linktr.ee/) is a third-party links aggregator that allows you to put all your links into one link.
For example:
![image](https://user-images.githubusercontent.com/17377423/133856588-67900e9e-bcb6-463f-8143-48ac1c86fd77.png)

So this PR is just for adding such support. I made this PR based on [this](https://github.com/HEIGE-PCloud/DoIt/commit/77fd6ef9b09e78c76be3cf76d3fcd21ed1346bf8) commit.

And this is how it looks like with this PR:
![2021-09-17 17-45-37](https://user-images.githubusercontent.com/17377423/133857080-3c1c7373-fcad-468f-8aa3-8636b0afb456.gif)

