### PR TITLE
Update pt-BR.toml to work with includedIn

### DIFF
--- a/i18n/pt-BR.toml
+++ b/i18n/pt-BR.toml
@@ -108,8 +108,19 @@ other = "Conteúdos"
 [publishedOnDate]
 other = "publicado em {{ .Date }}"
 
+[includedIn]
+other = "incluído "
+
+[includedInAnd]
+other = "e"
+
 [includedInCategories]
-other = "incluido em {{ .Categories }}"
+one = "na categoria {{ .Categories }}"
+other = "nas categorias {{ .Categories }}"
+
+[includedInSeries]
+one = "na série {{ .Series }}"
+other = "nas séries {{ .Series }}"
 
 [wordCount]
 one = "Uma palavra"


### PR DESCRIPTION
Will solve a issue happening in pt-BR where 'incluído na categoria' is shown as 'included in incluido na'.