### PR TITLE
Fix Ko-Fi icon

### DIFF
--- a/assets/data/social.yml
+++ b/assets/data/social.yml
@@ -515,7 +515,7 @@ ko-fi:
   Prefix: https://ko-fi.com/
   Title: Ko-Fi
   Icon:
-    Simpleicons: ko-fi
+    Simpleicons: kofi
 
 # 066: BuyMeaCoffee
 buymeacoffee:


### PR DESCRIPTION
I just found in the `simple-icons`, it's actually `kofi.svg` rather than `ko-fi.svg`, which will, apparently return 404.
`https://cdn.jsdelivr.net/npm/simple-icons@v5.8.1/icons/kofi.svg`
This is the fix for it.