### PR TITLE
feat(i18n): Add Korean translation strings

### DIFF
--- a/i18n/ko.toml
+++ b/i18n/ko.toml
@@ -1,0 +1,223 @@
+# Translations for Korean
+# https://gohugo.io/content-management/multilingual/#translation-of-strings
+
+# === baseof ==
+[backToTop]
+other = "맨 위로"
+
+[viewComments]
+other = "댓글 보기"
+# === baseof ==
+
+# === Post ===
+[posts]
+other = "글"
+# === Post ===
+
+# === Taxonomy ===
+[allSome]
+other = "모든 {{ .Some }}"
+
+[tag]
+other = "태그"
+
+[tags]
+other = "태그"
+
+[category]
+other = "분류"
+
+[categories]
+other = "분류"
+
+[series]
+other = "시리즈"
+# === Taxonomy ===
+
+# === Pagination ===
+[more]
+other = "더 보기"
+# === Pagination ===
+
+# === partials/header.html ===
+[selectLanguage]
+other = "언어 변경"
+
+[switchTheme]
+other = "테마 변경"
+
+[Light]
+other = "밝게"
+
+[Dark]
+other = "어둡게"
+
+[Black]
+other = "검정"
+
+[Auto]
+other = "자동"
+# === partials/header.html ===
+
+# === partials/footer.html ===
+[poweredBySome]
+other = "{{ .Hugo }}로 제작된 사이트 | {{ .Theme }} 테마"
+# === partials/footer.html ===
+
+# === partials/comment.html ===
+[valineLang]
+other = "ko"
+
+[valinePlaceholder]
+other = "댓글 작성..."
+
+[facebookLanguageCode]
+other = "ko-KR"
+# === partials/comment.html ===
+
+# === partials/assets.html ===
+[search]
+other = "검색"
+
+[searchPlaceholder]
+other = "제목이나 내용으로 검색..."
+
+[clear]
+other = "지우기"
+
+[cancel]
+other = "취소"
+
+[noResultsFound]
+other = "검색 결과 없음"
+
+[lunrLanguageCode]
+other = "ko"
+
+[copyToClipboard]
+other = "복사하기"
+
+[cookieconsentMessage]
+other = "본 웹사이트는 웹 환경 개선을 위해 쿠키를 사용합니다."
+
+[cookieconsentDismiss]
+other = "확인"
+
+[cookieconsentLink]
+other = "더 보기"
+# === partials/assets.html ===
+
+# === partials/plugin/share.html ===
+[shareOn]
+other = "공유하기"
+# === partials/plugin/share.html ===
+
+# === posts/single.html ===
+[contents]
+other = "목차"
+
+[publishedOnDate]
+other = "{{ .Date }} 작성"
+
+[includedIn]
+other = ""
+
+[includedInAnd]
+other = "|"
+
+[includedInCategories]
+one = "분류: {{ .Categories }}"
+other = "분류: {{ .Categories }}"
+
+[includedInSeries]
+other = "시리즈: {{ .Series }}"
+
+[wordCount]
+one = "한 단어"
+other = "{{ .Count }} 단어"
+
+[readingTime]
+one = "읽는데 약 1분"
+other = "읽는데 약 {{ .Count }}분"
+
+[views]
+other = "조회"
+
+[comments]
+other = "댓글"
+
+[author]
+other = "저자"
+
+[updatedOnDate]
+other = "{{ .Date }} 수정"
+
+[readMarkdown]
+other = "마크다운 읽기"
+
+[back]
+other = "뒤로"
+
+[home]
+other = "홈"
+
+[readMore]
+other = "더 읽기..."
+# === posts/single.html ===
+
+# === 404.html ===
+[pageNotFound]
+other = "Page not found"
+
+[pageNotFoundText]
+other = "해당 페이지를 찾을 수 없습니다."
+# === 404.html ===
+
+# === shortcodes/admonition.html ===
+[note]
+other = "노트"
+
+[abstract]
+other = "요약"
+
+[info]
+other = "정보"
+
+[tip]
+other = "팁"
+
+[success]
+other = "성공"
+
+[question]
+other = "질문"
+
+[warning]
+other = "경고"
+
+[failure]
+other = "실패"
+
+[danger]
+other = "위험"
+
+[bug]
+other = "버그"
+
+[example]
+other = "예시"
+
+[quote]
+other = "인용"
+# === shortcodes/admonition.html ===
+
+# === shortcodes/version.html ===
+[new]
+other = "신규"
+
+[changed]
+other = "변경"
+
+[deleted]
+other = "삭제"
+# === shortcodes/version.html ===


### PR DESCRIPTION
Information for whom can't understand Korean
* In Korean, generally there is no difference between singular and plural forms.  
  (not typo for `[tag]`-`[tags]`, `[category]`-`[categories]` and so on)
* To list up categories and series, It'd be better to express with colon used before list.
* It seems unnecessary to express with `[includedIn]` for Korean.  
  It'd be explicitly derived to understand the post's categories and series info.
* Didn't translate `[pageNotFound]` because I guess these short sentences may be acceptable for Koreans.

한국어를 이해하는 분들을 위한 정보 (Information for whom understands Korean)
* 기존 영문의 경우 문장형으로 서술되어있으나, 그대로 번역 시 과번역되는 듯 하여, 구절 형태로 번역하였습니다.
* 테마 선택에서 적절한 번역이 없는 것 같아서, 직설적으로 "밝게, 어둡게, 검정" 으로 번역했습니다.
* Shortcodes 중 abstract는 정황 상 "추상화"보단 논문 등의 "초록"의 의미를 가지는 것 같다 생각했고,  
  그보다는 "요약"이 적합한 표현이라 생각하여 이렇게 번역했습니다. (마침 summary가 따로 존재하지 않습니다.)