### PR TITLE
chore: hide lastmod when lastmod frontmatter is not set

### DIFF
--- a/layouts/partials/single/footer.html
+++ b/layouts/partials/single/footer.html
@@ -5,13 +5,15 @@
         <div class="post-info-line">
             <div class="post-info-mod">
                 <span>
-                    {{- with .Site.Params.dateformat | default "2006-01-02" | .Lastmod.Format -}}
-                        {{- dict "Date" . | T "updatedOnDate" -}}
-                        {{- if $.Site.Params.gitRepo -}}
-                            {{- with $.GitInfo -}}
-                                &nbsp;<a class="git-hash" href="{{ printf `%v/commit/%v` $.Site.Params.gitRepo .Hash }}" target="_blank" title="commit by {{ .AuthorName }}({{ .AuthorEmail }}) {{ .Hash }}: {{ .Subject }}" rel="noopener noreferrer">
-                                    <i class="fas fa-hashtag fa-fw"></i>{{- .AbbreviatedHash -}}
-                                </a>
+                    {{- if .Params.lastmod -}}
+                        {{- with .Site.Params.dateformat | default "2006-01-02" | .Lastmod.Format -}}
+                            {{- dict "Date" . | T "updatedOnDate" -}}
+                            {{- if $.Site.Params.gitRepo -}}
+                                {{- with $.GitInfo -}}
+                                    &nbsp;<a class="git-hash" href="{{ printf `%v/commit/%v` $.Site.Params.gitRepo .Hash }}" target="_blank" title="commit by {{ .AuthorName }}({{ .AuthorEmail }}) {{ .Hash }}: {{ .Subject }}" rel="noopener noreferrer">
+                                        <i class="fas fa-hashtag fa-fw"></i>{{- .AbbreviatedHash -}}
+                                    </a>
+                                {{- end -}}
                             {{- end -}}
                         {{- end -}}
                     {{- end -}}

--- a/layouts/posts/single.html
+++ b/layouts/posts/single.html
@@ -90,8 +90,10 @@
                 {{- with .Site.Params.dateformat | default "2006-01-02" | .PublishDate.Format -}}
                     <i class="far fa-calendar-alt fa-fw"></i>&nbsp;<time datetime="{{ . }}">{{ . }}</time>&nbsp;
                 {{- end -}}
-                {{- with .Site.Params.dateformat | default "2006-01-02" | .Lastmod.Format -}}
-                    <i class="far fa-edit fa-fw"></i>&nbsp;<time datetime="{{ . }}">{{ . }}</time>&nbsp;
+                {{- if .Params.lastmod -}}
+                    {{- with .Site.Params.dateformat | default "2006-01-02" | .Lastmod.Format -}}
+                        <i class="far fa-edit fa-fw"></i>&nbsp;<time datetime="{{ . }}">{{ . }}</time>&nbsp;
+                    {{- end -}}
                 {{- end -}}
                 <i class="fas fa-pencil-alt fa-fw"></i>&nbsp;{{ T "wordCount" .WordCount }}&nbsp;
                 <i class="far fa-clock fa-fw"></i>&nbsp;{{ T "readingTime" .ReadingTime }}&nbsp;


### PR DESCRIPTION
在 `config.toml` 中添加以下配置

```toml
[frontmatter]
  lastmod = ['lastmod']
```

确保 Hugo 仅使用 frontmatter 中的 lastmod 参数。

通过这样配置，`gitInfo` 不会生效，需要手动更新 `lastmod` 参数。