### PR TITLE
i18n: fix typo for pt-BR translation

### DIFF
--- a/i18n/pt-BR.toml
+++ b/i18n/pt-BR.toml
@@ -17,7 +17,7 @@ other = "Publicações"
 
 # === Taxonomy ===
 [allSome]
-other = "Todos {{ .Some }}"
+other = "Todas {{ .Some }}"
 
 [tag]
 other = "Tag"
@@ -131,7 +131,7 @@ other = "Conteúdos"
 other = "publicado em {{ .Date }}"
 
 [includedIn]
-other = "incluído em "
+other = "incluído "
 
 [includedInAnd]
 other = "e"


### PR DESCRIPTION
Was displaying 'Todos Categorias' instead of 'Todas Categorias'.
Was displaying, too,  'incluído em na categoria' instead of 'incluído na categoria'.