### PR TITLE
refactor: optimize toc logic

### DIFF
--- a/assets/css/_core/_media.scss
+++ b/assets/css/_core/_media.scss
@@ -2,11 +2,20 @@
   .page {
     width: 56%;
   }
+  #toc-auto {
+    left: 78%;
+    width: 22%;
+  }
 }
 
 @media only screen and (max-width: 1200px) {
   .page {
     width: 52%;
+  }
+
+  #toc-auto {
+    left: 76%;    
+    width: 24%;    
   }
 
   #header-desktop .header-wrapper {

--- a/assets/css/_partial/_single/_toc.scss
+++ b/assets/css/_partial/_single/_toc.scss
@@ -60,15 +60,13 @@
 #toc-auto {
   display: block;
   position: absolute;
-  width: $MAX_LENGTH;
-  max-width: 0;
   padding: 0 .8rem;
   border-left: 4px solid $global-border-color;
   @include overflow-wrap(break-word);
   box-sizing: border-box;
   top: 10rem;
-  left: 0;
-  visibility: hidden;
+  left: 80%;
+  width: 20%;
 
   [header-desktop=normal] & {
     top: 5rem;

--- a/assets/js/theme.js
+++ b/assets/js/theme.js
@@ -793,7 +793,6 @@ function onResize () {
       window._resizeTimeout = window.setTimeout(() => {
         window._resizeTimeout = null
         for (const event of window.resizeEventSet) event()
-        initToc()
         initSearch()
       }, 100)
     }

--- a/assets/js/theme.js
+++ b/assets/js/theme.js
@@ -612,6 +612,10 @@ function initToc () {
       // and all its parent to has-active
       if (activeTocIndex >= 0 && activeTocIndex < tocLinkElements.length) {
         tocLinkElements[activeTocIndex].classList.add('active')
+        tocLinkElements[activeTocIndex].scrollIntoView({
+          behavior: 'smooth',
+          block: 'center'
+        })
         let parent = tocLinkElements[activeTocIndex].parentElement
         while (parent !== tocCore) {
           parent.classList.add('has-active')
@@ -866,7 +870,7 @@ document.addEventListener('pjax:send', function () {
   delete window._tocOnScroll
   const el = document.getElementById('content')
   if (el) {
-    window.lgData[el?.getAttribute('lg-uid')].destroy(true)
+    window.lgData[el?.getAttribute('lg-uid')]?.destroy(true)
   }
 })
 

--- a/assets/js/theme.js
+++ b/assets/js/theme.js
@@ -551,29 +551,9 @@ function initToc () {
   const isTocStatic = window.matchMedia && window.matchMedia('only screen and (max-width: 1000px)').matches
 
   if (document.getElementById('toc-static').getAttribute('kept') || isTocStatic) {
-    const tocContentStatic = document.getElementById('toc-content-static')
-    if (tocCore.parentElement !== tocContentStatic) {
-      tocCore.parentElement.removeChild(tocCore)
-      tocContentStatic.appendChild(tocCore)
-    }
     if (window._tocOnScroll) window.scrollEventSet.delete(window._tocOnScroll)
   } else {
-    const tocContentAuto = document.getElementById('toc-content-auto')
-    if (tocCore.parentElement !== tocContentAuto) {
-      tocCore.parentElement.removeChild(tocCore)
-      tocContentAuto.appendChild(tocCore)
-    }
-    // The toc element
     const toc = document.getElementById('toc-auto')
-    // The page element
-    const page = document.getElementsByClassName('page')[0]
-    // The rect of the page
-    const rect = page.getBoundingClientRect()
-    // The toc is 20px to the right of the page
-    toc.style.left = `${rect.left + rect.width + 20}px`
-    // The toc occupy all the right of the window
-    toc.style.maxWidth = `${window.innerWidth - rect.right - 20}px`
-    toc.style.visibility = 'visible'
     const tocLinkElements = tocCore.querySelectorAll('a:first-child')
     const tocLiElements = tocCore.getElementsByTagName('li')
     const headerLinkElements = document.getElementsByClassName('headerLink')

--- a/layouts/posts/single.html
+++ b/layouts/posts/single.html
@@ -2,7 +2,6 @@
 
 {{- define "content" -}}
     {{- $params := .Scratch.Get "params" -}}
-
     {{- $toc := $params.toc -}}
     {{- if eq $toc true -}}
     {{- $toc = .Site.Params.page.toc | default dict -}}
@@ -12,10 +11,12 @@
     
     
     {{- /* Auto TOC */ -}}
-    {{- if ne $toc.enable false -}}
+    {{- if $toc.enable | and (eq $toc.keepStatic false) -}}
     <div class="toc" id="toc-auto">
         <h2 class="toc-title">{{ T "contents" }}</h2>
-        <div class="toc-content{{ if eq $toc.auto false }} always-active{{ end }}" id="toc-content-auto"></div>
+        <div class="toc-content{{ if eq $toc.auto false }} always-active{{ end }}" id="toc-content-auto">
+            {{- dict "Content" .TableOfContents "Ruby" $params.ruby "Fraction" $params.fraction "Fontawesome" $params.fontawesome | partial "function/content.html" | safeHTML -}}
+        </div>
     </div>
     {{- end -}}
     
@@ -183,14 +184,16 @@
         {{- end -}}
         
         {{- /* Static TOC */ -}}
-        {{- if ne $toc.enable false -}}
+        {{- if $toc.enable -}}
             <div class="details toc" id="toc-static"  kept="{{ if $toc.keepStatic }}true{{ end }}">
                 <div class="details-summary toc-title">
                     <span>{{ T "contents" }}</span>
                     <span><i class="details-icon fas fa-angle-right"></i></span>
                 </div>
                 <div class="details-content toc-content" id="toc-content-static">
+                {{- if $toc.keepStatic -}}
                     {{- dict "Content" .TableOfContents "Ruby" $params.ruby "Fraction" $params.fraction "Fontawesome" $params.fontawesome | partial "function/content.html" | safeHTML -}}
+                {{- end -}}
                 </div>
             </div>
         {{- end -}}


### PR DESCRIPTION
- use CSS to set its width instead of JavaScript code
- process the logic of static toc and auto toc in Hugo template instead of JavaScript code