### PR TITLE
fix: destroy all aplayer instances on pjax:send

### DIFF
--- a/assets/js/lib/aplayer.js
+++ b/assets/js/lib/aplayer.js
@@ -1,6 +1,8 @@
 /* eslint-disable no-new */
 import APlayer from 'aplayer'
 
+const aplayerInstances = []
+
 // Get all aplayer containers
 const aplayers = document.getElementsByClassName('aplayer-shortcode')
 Array.from(aplayers).forEach(aplayer => {
@@ -8,5 +10,9 @@ Array.from(aplayers).forEach(aplayer => {
   const options = JSON.parse(aplayer.dataset.options)
   options.audio = audio
   options.container = aplayer
-  new APlayer(options)
+  const ap = new APlayer(options)
+  aplayerInstances.push(ap)
 })
+
+// Destroy all instances on pjax:send
+document.addEventListener('pjax:send', () => aplayerInstances.forEach((aplayer) => aplayer.destroy()))

--- a/layouts/partials/assets.html
+++ b/layouts/partials/assets.html
@@ -184,7 +184,7 @@
 {{- end -}}
 
 {{- /* Music */ -}}
-{{- if (.Scratch.Get "this").music -}}
+{{- if (.Scratch.Get "this").aplayer | or (.Scratch.Get "this").music -}}
     {{- /* APlayer */ -}}
     {{- $source := $cdn.aplayerCSS | default "lib/aplayer/APlayer.min.css" -}}
     {{- dict "Source" $source "Fingerprint" $fingerprint "Defer" true | dict "Scratch" .Scratch "Data" | partial "scratch/pjaxStyle.html" -}}
@@ -193,19 +193,21 @@
     {{- $source := $cdn.aplayerJS | default "lib/aplayer/APlayer.min.js" -}}
     {{- dict "Source" $source "Fingerprint" $fingerprint "Defer" true | dict "Scratch" .Scratch "Data" | partial "scratch/pjaxScript.html" -}}
 
-    {{- /* MetingJS */ -}}
-    {{- $source := $cdn.metingJS | default "lib/meting/Meting.min.js" -}}
-    {{- dict "Source" $source "Fingerprint" $fingerprint "Defer" true | dict "Scratch" .Scratch "Data" | partial "scratch/pjaxScript.html" -}}
-    {{- $config = dict "music" true | merge $config -}}
-
-    {{- $shims := dict "aplayer" "js/shims/aplayer.js" -}}
-    {{- $options := dict -}}
-    {{- $options = dict "targetPath" "js/aplayer.min.js" | merge $options -}}
-    {{- $options = dict "minify" true | merge $options -}}
-    {{- $options = dict "shims" $shims | merge $options -}}
-    {{- $js := resources.Get "js/lib/aplayer.js" | js.Build $options -}}
-    {{- $_ := $js.RelPermalink -}}
-    {{- dict "Link" $js.RelPermalink "Fingerprint" $fingerprint "Defer" true | dict "Scratch" .Scratch "Data" | partial "scratch/pjaxScript.html" -}}
+    {{- if (.Scratch.Get "this").music -}}
+        {{- /* MetingJS */ -}}
+        {{- $source := $cdn.metingJS | default "lib/meting/Meting.min.js" -}}
+        {{- dict "Source" $source "Fingerprint" $fingerprint "Defer" true | dict "Scratch" .Scratch "Data" | partial "scratch/pjaxScript.html" -}}
+        {{- $config = dict "music" true | merge $config -}}
+    {{- else -}}
+        {{- $shims := dict "aplayer" "js/shims/aplayer.js" -}}
+        {{- $options := dict -}}
+        {{- $options = dict "targetPath" "js/aplayer.min.js" | merge $options -}}
+        {{- $options = dict "minify" true | merge $options -}}
+        {{- $options = dict "shims" $shims | merge $options -}}
+        {{- $js := resources.Get "js/lib/aplayer.js" | js.Build $options -}}
+        {{- $_ := $js.RelPermalink -}}
+        {{- dict "Link" $js.RelPermalink "Fingerprint" $fingerprint "Defer" true | dict "Scratch" .Scratch "Data" | partial "scratch/pjaxScript.html" -}}
+    {{- end -}}
 {{- end -}}
 
 {{- /* Cookie Consent */ -}}

--- a/layouts/shortcodes/aplayer.html
+++ b/layouts/shortcodes/aplayer.html
@@ -20,7 +20,7 @@
     {{- $_ = replace $_ ",]" "]" -}}
     <div class="aplayer-shortcode" {{- printf "data-audio='%s'" $_ | safeHTMLAttr -}} {{- printf "data-options='%s'" $options | safeHTMLAttr -}}></div>
 
-    {{- .Page.Scratch.SetInMap "this" "music" true -}}
+    {{- .Page.Scratch.SetInMap "this" "aplayer" true -}}
 
 {{- else -}}
     {{- errorf "Only named params is supported: %s" .Position -}}


### PR DESCRIPTION
chore: update aplayer template only load metingJS with music shortcode

Close #427 