### PR TITLE
fix: series_weight does not work in term pages

### DIFF
--- a/layouts/taxonomy/list.html
+++ b/layouts/taxonomy/list.html
@@ -44,7 +44,7 @@
         {{- if .Pages -}}
             {{- $taxonomy := .Data.Singular -}}
             {{- if eq $taxonomy "series" -}}
-                {{- $pages := .Pages -}}
+                {{- $pages := .Pages.ByParam "series_weight" -}}
                 {{- with .Site.Params.list.paginate | default .Site.Params.paginate -}}
                     {{- $pages = $.Paginate $pages . -}}
                 {{- else -}}


### PR DESCRIPTION
Fixes #416 
在 list.html 中设置页面按照 series_weight 排序, 修复 #416 关于系列权重无效的问题