### PR TITLE
fix: series lists named in non-English do not show in the single page

### DIFF
--- a/layouts/posts/single.html
+++ b/layouts/posts/single.html
@@ -157,7 +157,7 @@
         {{- if $params.series | and $params.seriesNavigation -}}
                 {{- range $key, $value := .Site.Taxonomies.series -}}
                     {{- range $params.series -}}
-                        {{- if . | urlize | eq $key -}}
+                        {{- if . | urlize | eq ($key | urlize) -}}
                             {{- $term := $.Site.GetPage "series" $key -}}
                             <div class="details series-nav open">
                                 <div class="details-summary series-title">


### PR DESCRIPTION
Fixes #477 