### PR TITLE
fix(scrollbar): use $custom-scrollbar var in table wrapper

### DIFF
--- a/assets/css/_page/_single.scss
+++ b/assets/css/_page/_single.scss
@@ -197,14 +197,16 @@
     .table-wrapper {
       overflow-x: auto;
 
-      &::-webkit-scrollbar {
-        background-color: $table-background-color;
-
-        [theme=dark] & {
-          background-color: $table-background-color-dark;
-        }
-        [theme=black] & {
-          background-color: $table-background-color-black;
+      @if $custom-scrollbar {
+        &::-webkit-scrollbar {
+          background-color: $table-background-color;
+  
+          [theme=dark] & {
+            background-color: $table-background-color-dark;
+          }
+          [theme=black] & {
+            background-color: $table-background-color-black;
+          }
         }
       }
 

--- a/assets/css/_page/_single.scss
+++ b/assets/css/_page/_single.scss
@@ -208,6 +208,17 @@
             background-color: $table-background-color-black;
           }
         }
+
+        ::-webkit-scrollbar-corner {
+          background-color: $table-background-color;
+
+          [theme=dark] & {
+            background-color: $table-background-color-dark;
+          }
+          [theme=black] & {
+            background-color: $table-background-color-black;
+          }
+        }
       }
 
       > table {


### PR DESCRIPTION
It looks like the use of `$custom-scrollbar` was omitted for the table wrapper. This results in a small visual bug on macOS 11.6/Chrome 99.0.

Before (notice the small white rectangle at the bottom right):

<img width="910" alt="Screenshot 2022-04-04 at 21 01 19" src="https://user-images.githubusercontent.com/1479737/161549536-d1d26ceb-b9d3-4b3e-9f32-839d70df0356.png">

After:

<img width="855" alt="Screenshot 2022-04-04 at 21 05 25" src="https://user-images.githubusercontent.com/1479737/161549989-e194a3bd-06e8-4db6-a191-bae26a25ef9d.png">
