### PR TITLE
feat: allow customising the sponsor button

### DIFF
--- a/assets/css/_partial/_single/_sponsor.scss
+++ b/assets/css/_partial/_single/_sponsor.scss
@@ -25,20 +25,26 @@
         padding: 5px 10px;
         margin: 15px auto;
         display: inline-block;
-        background-color: #f0f0f0;
+        background-color: $sponsor-button-background-color;
         -webkit-transition: transform 0.4s ease;
         -moz-transition: transform 0.4s ease;
         -o-transition: transform 0.4s ease;
         transition: transform 0.4s ease;
         &:hover {
-            background-color: #f0f0f0;
+            background-color: $sponsor-button-hover-background-color;
             @include transform(scale(1.05));
         }
         [theme="dark"] & {
-            background-color: #363636;
+            background-color: $sponsor-button-background-color-dark;
+            &:hover {
+                background-color: $sponsor-button-hover-background-color-dark;
+            }
         }
         [theme="black"] & {
-            background-color: #363636;
+            background-color: $sponsor-button-background-color-black;
+            &:hover {
+                background-color: $sponsor-button-hover-background-color-black;
+            }
         }
         span {
             vertical-align: top;

--- a/assets/css/_variables.scss
+++ b/assets/css/_variables.scss
@@ -475,3 +475,16 @@ $friend-link-hover-color: #ef3982 !default;
 $friend-link-hover-color-dark: #ffffff !default;
 $friend-link-hover-color-black: #ffffff !default;
 // ========== Friend Link ========== //
+
+
+// ========== Sponsor Button ========== //
+// Sponsor button background color
+$sponsor-button-background-color: #f0f0f0 !default;
+$sponsor-button-background-color-dark: #363636 !default;
+$sponsor-button-background-color-black: #363636 !default;
+
+// Sponsor button background color while in the :hover state
+$sponsor-button-hover-background-color: #f0f0f0 !default;
+$sponsor-button-hover-background-color-dark: #363636 !default;
+$sponsor-button-hover-background-color-black: #363636 !default;
+// ========== Sponsor Button ========== //


### PR DESCRIPTION
Just as the title says, allow users to customise their sponsor button background and colour.

https://user-images.githubusercontent.com/1479737/161555432-c5d65e7e-c28e-43e7-9612-63c62d46a3e9.mov


