### PR TITLE
introduce data-strict for giscus

### DIFF
--- a/assets/js/lib/giscus.js
+++ b/assets/js/lib/giscus.js
@@ -13,6 +13,7 @@ if (window.config?.comment?.giscus) {
   script.setAttribute('data-input-position', giscusConfig.dataInputPosition)
   script.setAttribute('data-theme', window.isDark ? giscusConfig.darkTheme : giscusConfig.lightTheme)
   script.setAttribute('data-lang', giscusConfig.dataLang)
+  script.setAttribute('data-strict', giscusConfig.dataStrict)
   script.crossOrigin = 'anonymous'
   script.async = true
   document.getElementById('giscus').appendChild(script)


### PR DESCRIPTION
Avoid mismatches due to GitHub's fuzzy searching method when there are multiple discussions with similar titles. See [the documentation](https://github.com/giscus/giscus/blob/main/ADVANCED-USAGE.md#data-strict) for more details.