### PR TITLE
fix: wrong utterances's login redirect link & post's prevLink/nextLink

### DIFF
--- a/assets/js/theme.js
+++ b/assets/js/theme.js
@@ -883,7 +883,10 @@ new Pjax({
     '.pjax-assets',
     '#fixed-buttons',
     '.search-dropdown',
-    '.header-title'
+    '.header-title',
+    'link[rel="canonical"]',
+    'link[rel="prev"]',
+    'link[rel="next"]',
   ]
 })
 


### PR DESCRIPTION
Pjax do not refresh page's canonical link, which caused wrong redirect link of utterances's login button, this PR fix it.

related issues:

- https://github.com/utterance/utterances/issues/474#issuecomment-774887936