### PR TITLE
bugfix: Fix a render-image hook issue

### DIFF
--- a/layouts/_default/_markup/render-image.html
+++ b/layouts/_default/_markup/render-image.html
@@ -1,8 +1,8 @@
-{{- if .Title -}}
+{{- if .Text -}}
     <figure>
         {{- dict "Src" .Destination "Title" .Text "Caption" .Title "Linked" true "Resources" .Page.Resources | partial "plugin/image.html" -}}
         <figcaption class="image-caption">
-            {{- .Title | safeHTML -}}
+            {{- .Text | safeHTML -}}
         </figcaption>
     </figure>
 {{- else -}}


### PR DESCRIPTION
Using markdown image syntax directly can lead a wrong layout. This is also an obstacle for other users to migrate over :bug:
After fixing it, markdown image syntax works :tada: