### PR TITLE
feat: add markdown support for taxonomy introduction

### DIFF
--- a/layouts/taxonomy/list.html
+++ b/layouts/taxonomy/list.html
@@ -3,6 +3,8 @@
 {{- end -}}
 
 {{- define "content" -}}
+    {{- $params := .Scratch.Get "params" -}}
+
     <div class="page archive">
         {{- /* Title */ -}}
         <h2 class="single-title animate__animated animate__pulse animate__faster">
@@ -39,9 +41,11 @@
             {{- end -}}
         </h2>
         {{- /* Introduction*/ -}}
-        {{- with .Params.introduction -}}
+        {{- if .Content -}}
         <div class="introduction">
-            <blockquote>{{- . -}}</blockquote>
+            <blockquote>
+                {{- dict "Content" .Content "Ruby" $params.ruby "Fraction" $params.fraction "Fontawesome" $params.fontawesome | partial "function/content.html" | safeHTML -}}
+            </blockquote>
         </div>
         {{- end -}}
         {{- /* Paginate */ -}}


### PR DESCRIPTION
目前版本的 taxonomy introduction 只支持纯文本. 之前尝试过 `.Params.introduction | .safeHTML`, 在 introduction 里写 HTML 的方法, 但是会出现一些问题.

我的想法是不用 `.Params.introduction`, 而是直接使用 `.Content`, 然后在 `_index.md` 中写内容. 效果如下:

![Screenshot from 2022-10-28 16-50-26](https://user-images.githubusercontent.com/50052878/198546281-9b3d3b47-17c8-46b2-9906-f21a0abbe184.png)

`_index.md`:
```markdown
---
title: Learning MIT 6.S081
---

**Learning MIT 6.S081 Fall 2020, Operating System Engineering.**

- [MIT website](https://pdos.csail.mit.edu/6.S081/2020/)
- [Chinese translation](https://mit-public-courses-cn-translatio.gitbook.io/mit6-s081/)

```

