### PR TITLE
[Bug fix] increase robustness of feat_img process pipeline

### DIFF
--- a/layouts/posts/single.html
+++ b/layouts/posts/single.html
@@ -139,9 +139,13 @@
         {{- $width := "auto" -}}
         {{- $height := "auto" -}}
         {{- with .Resources.GetMatch (printf "**%s" $params.featuredimage) -}}
-            {{- $image = .RelPermalink -}}
-            {{- $width = .Width -}}
-            {{- $height = .Height -}}
+            {{- if eq .ResourceType "image" -}}
+                {{- $image = .RelPermalink -}}
+                {{- $width = .Width -}}
+                {{- $height = .Height -}}
+            {{- else -}}
+                {{- warnf "invalid featured image detected!" }}
+            {{- end -}}
         {{- end -}}
         {{- with .Resources.GetMatch "featured-image" -}}
             {{- $image = .RelPermalink -}}

--- a/layouts/posts/single.html
+++ b/layouts/posts/single.html
@@ -144,7 +144,7 @@
                 {{- $width = .Width -}}
                 {{- $height = .Height -}}
             {{- else -}}
-                {{- warnf "invalid featured image detected!" }}
+                {{- warnf "invalid featured image detected!" -}}
             {{- end -}}
         {{- end -}}
         {{- with .Resources.GetMatch "featured-image" -}}


### PR DESCRIPTION
## 复现
将`exampleSite`下的`config.toml`的中文配置删除（279-521行），构建时就会出现以下报错。
```shell
"/home/runner/work/DoIt/DoIt/layouts/posts/single.html:143:25": execute of template failed: template: posts/single.html:143:25: executing "content" at <.Width>: can't evaluate field Width in type resource.Resource
```

## bug原因
`exampleSite`下的[create-diagrams](https://github.com/HEIGE-PCloud/DoIt/tree/main/exampleSite/content/posts/how-to-DoIt/create-diagrams)内的参数`featureImage`为空，理论上来说按照`single.html`所使用的`with`方法这个空参数是不会被传入的，但我看作者您在这里貌似使用了一些其他的处理方式让这个空值也会被传入，从而导致`Hugo`无法获取到资源的宽度从而报错。

## 修复方法
加了一个判断文件类型的逻辑，只有检测到输入为图片时才会进行后续操作。