### PR TITLE
fix: add line height to h1 text

### DIFF
--- a/assets/css/_page/_single.scss
+++ b/assets/css/_page/_single.scss
@@ -395,6 +395,7 @@
 
     .headerLink {
       scroll-margin-top: 3.5rem;
+      line-height: 140%;
     }
 
     sup {


### PR DESCRIPTION
文章内的 h1 标题换行后会出现重叠的错误

![image](https://user-images.githubusercontent.com/57262511/230841390-7f26b34e-c972-4d23-9ba8-b8e5079f25fa.png)

修正了一下行距