### PR TITLE
bump DoIt version string in the footer

### DIFF
--- a/layouts/partials/init.html
+++ b/layouts/partials/init.html
@@ -1,4 +1,4 @@
-{{- .Scratch.Set "version" "0.3.0" -}}
+{{- .Scratch.Set "version" "0.4.0" -}}
 
 {{- /* DoIt theme version detection */ -}}
 {{/*  {{- $VERSION := "0.3.X" -}}


### PR DESCRIPTION
This is just a tiny PR to bump the DoIt version string. This string is visible when you hover your mouse on the footer `DoIt`
![2023-05-26 22-50-51](https://github.com/HEIGE-PCloud/DoIt/assets/17377423/c526856f-1db2-4ea4-83ba-2d4c10b65e41)
