### PR TITLE
feature: enableWordCount, enableReadingTime, enableLastMod

### DIFF
--- a/layouts/posts/single.html
+++ b/layouts/posts/single.html
@@ -84,11 +84,17 @@
                 {{- with .Site.Params.dateformat | default "2006-01-02" | .PublishDate.Format -}}
                     <i class="far fa-calendar-alt fa-fw"></i>&nbsp;<time datetime="{{ . }}">{{ . }}</time>&nbsp;
                 {{- end -}}
-                {{- with .Site.Params.dateformat | default "2006-01-02" | .Lastmod.Format -}}
-                    <i class="far fa-edit fa-fw"></i>&nbsp;<time datetime="{{ . }}">{{ . }}</time>&nbsp;
+                {{- if $params.enableLastMod | default true -}}
+                    {{- with .Site.Params.dateformat | default "2006-01-02" | .Lastmod.Format -}}
+                        <i class="far fa-edit fa-fw"></i>&nbsp;<time datetime="{{ . }}">{{ . }}</time>&nbsp;
+                    {{- end -}}
                 {{- end -}}
-                <i class="fas fa-pencil-alt fa-fw"></i>&nbsp;{{ T "wordCount" .WordCount }}&nbsp;
-                <i class="far fa-clock fa-fw"></i>&nbsp;{{ T "readingTime" .ReadingTime }}&nbsp;
+                {{- if $params.enableWordCount | default true -}}
+                    <i class="fas fa-pencil-alt fa-fw"></i>&nbsp;{{ T "wordCount" .WordCount }}&nbsp;
+                {{- end -}}
+                {{- if $params.enableReadingTime | default true -}}
+                    <i class="far fa-clock fa-fw"></i>&nbsp;{{ T "readingTime" .ReadingTime }}&nbsp;
+                {{- end -}}
                 {{- $comment := .Scratch.Get "comment" | default dict -}}
                 {{- /* Visitor Count */ -}}
                 {{- if $comment.enable | and $comment.valine.enable | and $comment.valine.visitor -}}


### PR DESCRIPTION
Allow to hide `lastmod`, `wordCount` and `readingTime` in single page view.

Configurable in params.toml

```toml
[page]
  enableLastMod = false
  enableWordCount = false
  enableReadingTime = true
  ...
```