### PR TITLE
Fixed image alt text generation

### DIFF
--- a/layouts/partials/plugin/image.html
+++ b/layouts/partials/plugin/image.html
@@ -24,7 +24,8 @@
     {{- $large = .RelPermalink -}}
 {{- end -}}
 
-{{- $alt := .Alt | default $src -}}
+{{- $alt := .Alt | default .Title -}}
+{{- $alt := $alt | default $src -}}
 {{- $loading := .Loading | default "lazy" -}}
 
 {{- with .Height -}}


### PR DESCRIPTION
When I use Markdown's image syntax like below
`![An unexpected error was encountered while executing a WSL command](docker-hyperv-unexpected-error.png "Docker in Hyper-V error")`
I get next rendered image
![Screenshot 2023-06-13 164004](https://github.com/HEIGE-PCloud/DoIt/assets/127358482/9da1ec96-5e43-47e9-b78f-9b433720006a)

There is src path in alt tag, though should be alternative text.

This patch adds image title lookup between `Alt` and `src`. Rendered image becomes
![Screenshot 2023-06-13 163848](https://github.com/HEIGE-PCloud/DoIt/assets/127358482/af96c48a-f687-4711-83c1-23278d625c38)
