### PR TITLE
fix: fix typo in image.html

### DIFF
--- a/layouts/partials/plugin/image.html
+++ b/layouts/partials/plugin/image.html
@@ -7,7 +7,7 @@
     {{- $src = .RelPermalink -}}
     {{- if and
         (eq .ResourceType "image")
-        (dict "Path" $src "Suffixed" $suffixList | partial "function/suffixValidation.html")
+        (dict "Path" $src "Suffixes" $suffixList | partial "function/suffixValidation.html")
         -}}
         {{- $height = .Height -}}
         {{- $width = .Width -}}


### PR DESCRIPTION
Fixed a typo in the image.html file where the variable name "Suffixes" was misspelled as "Suffixed".

Might fix #1005 