### PR TITLE
experimental: View Transition on Navigation

### DIFF
--- a/layouts/_default/section.html
+++ b/layouts/_default/section.html
@@ -22,7 +22,7 @@
                 <h3 class="group-title">{{ .Key }}</h3>
                 {{- range .Pages -}}
                     <article class="archive-item">
-                        <a href="{{ .RelPermalink }}" class="archive-item-link">
+                        <a href="{{ .RelPermalink }}" class="archive-item-link" style="view-transition-name: {{ (replaceRE "[^A-Za-z0-9]" "" .Title) | safeCSS}}">
                             {{- .Title -}}
                         </a>
                         <span class="archive-item-date">

--- a/layouts/_default/summary.html
+++ b/layouts/_default/summary.html
@@ -23,7 +23,7 @@
     {{- with $image -}}
         <div class="featured-image-preview">
             <a href="{{ $.RelPermalink }}" aria-label={{ $.Title }}>
-                {{- dict "Src" . "Title" $.Description "Resources" $.Resources "Height" $height "Width" $width "Loading" "eager" | partial "plugin/image.html" -}}
+                {{- dict "Src" . "Title" $.Description "Resources" $.Resources "Height" $height "Width" $width "Loading" "eager" "ViewTransitionName" (printf "featured-image-%v" (replace $.Title " " "")) | partial "plugin/image.html" -}}
             </a>
         </div>
     {{- end -}}

--- a/layouts/_default/summary.html
+++ b/layouts/_default/summary.html
@@ -23,7 +23,7 @@
     {{- with $image -}}
         <div class="featured-image-preview">
             <a href="{{ $.RelPermalink }}" aria-label={{ $.Title }}>
-                {{- dict "Src" . "Title" $.Description "Resources" $.Resources "Height" $height "Width" $width "Loading" "eager" "ViewTransitionName" (printf "featured-image-%v" (replace $.Title " " "")) | partial "plugin/image.html" -}}
+                {{- dict "Src" . "Title" $.Description "Resources" $.Resources "Height" $height "Width" $width "Loading" "eager" "ViewTransitionName" (printf "featured-image-%v" (replaceRE "[^A-Za-z0-9]" "" $.Title) | safeCSS) | partial "plugin/image.html" -}}
             </a>
         </div>
     {{- end -}}

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -21,7 +21,7 @@
         {{- /* Posts */ -}}
         {{- if ne $posts.enable false | and .Site.RegularPages -}}
             {{- /* Paginate */ -}}
-            {{- $pages := where .Site.RegularPages "Type" "posts" -}}
+            {{- $pages := where .Site.RegularPages "Type" "in" site.Params.mainSections -}}
             {{- if .Site.Params.page.hiddenFromHomePage -}}
                 {{- $pages = where $pages "Params.hiddenfromhomepage" false -}}
             {{- else -}}

--- a/layouts/index.rss.xml
+++ b/layouts/index.rss.xml
@@ -36,7 +36,7 @@
         {{ with .OutputFormats.Get "RSS" }}
             {{ printf "<atom:link href=%q rel=\"self\" type=%q />" .Permalink .MediaType | safeHTML }}
         {{ end }}
-        {{- range where .Site.RegularPages "Type" "posts" | first (.Site.Params.home.rss | default 10) -}}
+        {{- range where .Site.RegularPages "Type" "in" site.Params.mainSections | first (.Site.Params.home.rss | default 10) -}}
             {{- dict "Page" . "Site" .Site | partial "rss/item.html" -}}
         {{- end -}}
     </channel>

--- a/layouts/partials/head/meta.html
+++ b/layouts/partials/head/meta.html
@@ -9,6 +9,7 @@
 <meta name="apple-mobile-web-app-title" content="{{ .Site.Params.app.title | default .Site.Title }}">
 
 <meta name="theme-color" content="#f8f8f8">
+<meta name="view-transition" content="same-origin" />
 
 {{- with .Site.Params.app.tileColor -}}
     <meta name="msapplication-TileColor" content="{{ . }}">

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -32,7 +32,7 @@
                     {{- with .Page -}}
                         {{- $url = .RelPermalink -}}
                     {{- end -}}
-                    <a class="menu-item{{ if $.IsMenuCurrent `main` . | or ($.HasMenuCurrent `main` .) | or (eq $.RelPermalink $url) }} active{{ end }}" href="{{ $url }}"{{ with .Title }} title="{{ . }}"{{ end }}{{ if (urls.Parse $url).Host }} rel="noopener noreferrer" target="_blank"{{ end }}>
+                    <a class="menu-item{{ if $.IsMenuCurrent `main` . | or ($.HasMenuCurrent `main` .) | or (eq $.RelPermalink $url) }} active{{ end }}" href="{{ $url }}"{{ with .Title }} title="{{ . }}"{{ end }}{{ if (urls.Parse $url).Host }} rel="noopener noreferrer" target="_blank"{{ end }} style="view-transition-name: menu-item-{{ .Name | safeCSS }}">
                         {{- .Pre | safeHTML }} {{ .Name }} {{ .Post | safeHTML -}}
                     </a>
                 {{- end -}}

--- a/layouts/partials/plugin/image.html
+++ b/layouts/partials/plugin/image.html
@@ -43,6 +43,7 @@
             src="{{ $src | safeURL }}"
             srcset="{{ $small | safeURL }}, {{ $src | safeURL }} 1.5x, {{ $large | safeURL }} 2x"
             sizes="auto"
+            {{ with .ViewTransitionName }}style="view-transition-name: {{ . | safeCSS }};"{{ end }}
             alt="{{ $alt }}"{{ with $height }} height="{{ . }}" {{ end }}{{ with $width }} width="{{ . }}" {{ end }}>
     </a>
 {{- else -}}
@@ -53,5 +54,5 @@
         srcset="{{ $small | safeURL }}, {{ $src | safeURL }} 1.5x, {{ $large | safeURL }} 2x"
         sizes="auto"
         alt="{{ $alt }}"
-        title="{{ .Title | default $alt }}"{{ with $height }} height="{{ . }}" {{ end }} {{ with $width }} width="{{ . }}" {{ end }}>
+        title="{{ .Title | default $alt }}"{{ with $height }} height="{{ . }}" {{ end }} {{ with $width }} width="{{ . }}" {{ end }}{{ with .ViewTransitionName }}style="view-transition-name: {{ . | safeCSS }};"{{ end }}>
 {{- end -}}

--- a/layouts/posts/single.html
+++ b/layouts/posts/single.html
@@ -33,7 +33,7 @@
 
     <article class="page single">
         {{- /* Title */ -}}
-        <h1 class="single-title animate__animated animate__flipInX">{{ .Title }}</h1>
+        <h1 class="single-title" style="view-transition-name: {{ (replaceRE "[^A-Za-z0-9]" "" .Title) | safeCSS}}">{{ .Title }}</h1>
 
         {{- /* Subtitle */ -}}
         {{- with $params.subtitle -}}
@@ -164,7 +164,7 @@
         {{- end -}}
         {{- with $image -}}
             <div class="featured-image">
-                {{- dict "Src" . "Title" $.Description "Resources" $.Resources "Width" $width "Height" $height "Loading" "eager" "ViewTransitionName" (printf "featured-image-%v" (replace $.Title " " "")) | partial "plugin/image.html" -}}
+                {{- dict "Src" . "Title" $.Description "Resources" $.Resources "Width" $width "Height" $height "Loading" "eager" "ViewTransitionName" (printf "featured-image-%v" (replaceRE "[^A-Za-z0-9]" "" $.Title) | safeCSS) | partial "plugin/image.html" -}}
             </div>
         {{- end -}}      
         {{- /* Series list */ -}}

--- a/layouts/posts/single.html
+++ b/layouts/posts/single.html
@@ -164,7 +164,7 @@
         {{- end -}}
         {{- with $image -}}
             <div class="featured-image">
-                {{- dict "Src" . "Title" $.Description "Resources" $.Resources "Width" $width "Height" $height "Loading" "eager" | partial "plugin/image.html" -}}
+                {{- dict "Src" . "Title" $.Description "Resources" $.Resources "Width" $width "Height" $height "Loading" "eager" "ViewTransitionName" (printf "featured-image-%v" (replace $.Title " " "")) | partial "plugin/image.html" -}}
             </div>
         {{- end -}}      
         {{- /* Series list */ -}}

--- a/layouts/shortcodes/showcase.html
+++ b/layouts/shortcodes/showcase.html
@@ -23,10 +23,10 @@
 <div class="showcase-box column-{{ $column }}">
     <div class="showcase-image">
         <a href={{ $link }}>
-            {{- dict "Src" $image "Height" "200" "Width" "400" "Title" $title | partial "plugin/image.html" -}}
+            {{- dict "Src" $image "Height" "200" "Width" "400" "Title" $title "ViewTransitionName" (printf "featured-image-%v" (replaceRE "[^A-Za-z0-9]" "" $title) | safeCSS) | partial "plugin/image.html" -}}
         </a>
     </div>
-    <h2 class="showcase-title">
+    <h2 class="showcase-title" style="view-transition-name: {{ (replaceRE "[^A-Za-z0-9]" "" $title) | safeCSS }}">
         <a href={{ $link }}>{{ $title }}</a>
     </h2>
     <p class="showcase-summary">


### PR DESCRIPTION
This is an experimental feature of Chrome relying on the experimental View Transitions API. 
Read more about it here: https://developer.chrome.com/docs/web-platform/view-transitions/ 
File your feedback here: https://github.com/w3c/csswg-drafts/labels/css-view-transitions-1

To view the effect

1. Install [Chrome Canary](https://www.google.com/chrome/canary/)
2. Turn on `chrome://flags/#view-transition` flag
3. Turn on `chrome://flags/#view-transition-on-navigation` flag

https://github.com/HEIGE-PCloud/DoIt/assets/52968553/71dd0925-69a4-489f-8979-0c312afffd3e

