### PR TITLE
Fix cursor missing issue

### DIFF
--- a/assets/js/theme.js
+++ b/assets/js/theme.js
@@ -225,7 +225,10 @@ function initSearch () {
     window._searchDesktopOnce = true
     // Turn on the mask when clicking on the search button
     searchToggle.addEventListener('click', () => {
-      loadScript('autocomplete-script', '/lib/autocomplete/autocomplete.min.js', () => initAutosearch())
+      loadScript('autocomplete-script', '/lib/autocomplete/autocomplete.min.js', () => {
+        initAutosearch();
+        searchInput.focus();
+      })
       if (window.config?.search?.type === 'algolia') {
         loadScript('algolia-script', '/lib/algoliasearch/algoliasearch-lite.umd.min.js', null)
       } else {
@@ -233,7 +236,6 @@ function initSearch () {
       }
       document.body.classList.add('blur')
       header.classList.add('open')
-      searchInput.focus()
     })
     // Clear the search box when clicking on the clear button
     searchClear.addEventListener('click', () => {


### PR DESCRIPTION
**Issue: The cursor is missing when the search button is first clicked.**

I have reviewed the code and it seems that `searchInput.focus()` does not work the first time.

To address this, I moving the `searchInput.focus()` line inside the onload callback function of the loadScript function. This change ensures that the focus is set after the script has finished loading.

![Animation](https://github.com/HEIGE-PCloud/DoIt/assets/25995001/31e238cb-db77-43f1-b094-2b15b779c89d)
