### PR TITLE
Update Artalk config document

### DIFF
--- a/exampleSite/content/posts/theme-documentation-basics/index.en.md
+++ b/exampleSite/content/posts/theme-documentation-basics/index.en.md
@@ -687,7 +687,7 @@ Please open the code block below to view the complete sample configuration :(far
         darkTheme = "dark"
         dataLang = "en"
       # {{< link "https://artalk.js.org/" "artalk" >}} comment config
-      [page.comment.artalk]
+      [params.page.comment.artalk]
         enable = false
         server = ""
         site = ""

--- a/exampleSite/content/posts/theme-documentation-basics/index.zh-cn.md
+++ b/exampleSite/content/posts/theme-documentation-basics/index.zh-cn.md
@@ -691,7 +691,7 @@ hugo
         darkTheme = "dark"
         dataLang = "zh-CN"
       # {{< link "https://artalk.js.org/" "artalk" >}} 评论系统设置
-      [page.comment.artalk]
+      [params.page.comment.artalk]
         enable = false
         server = ""
         site = ""


### PR DESCRIPTION
更改文档中错误配置

正确配置应该如下：

```toml
# [artalk](https://artalk.js.org/) 评论系统设置
      [params.page.comment.artalk]
        enable = false
        server = ""
        site = ""
        lite = false
        katex = false
        lightbox = false
        pageview = true
        commentCount = true
```

Resolve #1092 