### PR TITLE
Per SEO recommendations H1 tags should be present on pages.

### DIFF
--- a/layouts/_default/section.html
+++ b/layouts/_default/section.html
@@ -5,9 +5,9 @@
 {{- define "content" -}}
     <div class="page archive">
         {{- /* Title */ -}}
-        <h2 class="single-title animate__animated animate__pulse animate__faster">
+        <h1 class="single-title animate__animated animate__pulse animate__faster">
             {{- .Params.Title | default (T .Section) | default .Section | dict "Some" | T "allSome" -}}
-        </h2>
+        </h1>
 
         {{- /* Paginate */ -}}
         {{- if .Pages -}}
@@ -19,7 +19,7 @@
             {{- end -}}
             {{- partial "recentlyUpdated.html" . -}}
             {{- range $pages.PageGroups -}}
-                <h3 class="group-title">{{ .Key }}</h3>
+                <h2 class="group-title">{{ .Key }}</h2>
                 {{- range .Pages -}}
                     <article class="archive-item">
                         <a href="{{ .RelPermalink }}" class="archive-item-link">

--- a/layouts/partials/recentlyUpdated.html
+++ b/layouts/partials/recentlyUpdated.html
@@ -9,7 +9,7 @@
                 {{- if ne .Lastmod.Unix .Date.Unix }}
                     {{- $postCount = add $postCount 1 -}}
                     {{- if eq $hasTitle false -}}
-                        <h3 class="group-title">{{- T "recentlyUpdated" -}}</h3>
+                        <h2 class="group-title">{{- T "recentlyUpdated" -}}</h2>
                         {{- $hasTitle = true -}}
                     {{- end -}}
                     <article class="archive-item">

--- a/layouts/taxonomy/list.html
+++ b/layouts/taxonomy/list.html
@@ -7,7 +7,7 @@
 
     <div class="page archive">
         {{- /* Title */ -}}
-        <h2 class="single-title animate__animated animate__pulse animate__faster">
+        <h1 class="single-title animate__animated animate__pulse animate__faster">
             {{- $taxonomy := .Data.Singular -}}
             {{- if eq $taxonomy "category" -}}
                 <i class="far fa-folder-open fa-fw"></i>&nbsp;{{ .Title }}
@@ -39,7 +39,7 @@
             {{- else -}}
                 {{- printf "%v - %v" (T $taxonomy | default $taxonomy) .Title -}}
             {{- end -}}
-        </h2>
+        </h1>
         {{- /* Introduction*/ -}}
         {{- if .Content -}}
         <div class="introduction">

--- a/layouts/taxonomy/terms.html
+++ b/layouts/taxonomy/terms.html
@@ -8,9 +8,9 @@
 
     <div class="page archive">
         {{- /* Title */ -}}
-        <h2 class="single-title animate__animated animate__pulse animate__faster">
+        <h1 class="single-title animate__animated animate__pulse animate__faster">
             {{- .Params.Title | default (T $taxonomies) | default $taxonomies | dict "Some" | T "allSome" -}}
-        </h2>
+        </h1>
 
         {{- /* Categories Page */ -}}
         {{- if eq $taxonomies "categories" -}}
@@ -22,11 +22,11 @@
                     {{- with $.Site.GetPage "taxonomy" (printf "%v/%v" $type $term) -}}
                     <div class="card-item">
                         <div class="card-item-wrapper">
-                            <h3 class="card-item-title">
+                            <h2 class="card-item-title">
                                 <a href="{{ .RelPermalink }}">
                                     <i class="far fa-folder fa-fw"></i>&nbsp;{{ .Page.Title }} <sup>{{- len $pages -}}</sup>
                                 </a>
-                            </h3>
+                            </h2>
                             {{- range first 5 $pages -}}
                                 <article class="archive-item">
                                     <a href="{{ .RelPermalink }}" class="archive-item-link">


### PR DESCRIPTION
Per SEO recommendations (semrush) H1 tags should be present on pages.

```
About this issue

While less important than <title> tags, h1 headings still help define your page’s topic for search engines and users. If an <h1> tag is empty or missing, search engines may place your page lower than they would otherwise. Besides, a lack of an <h1> tag breaks your page’s heading hierarchy, which is not SEO friendly.
How to fix it

Provide a concise, relevant h1 heading for each of your page.
Category:Meta tags, Indexability
```