### PR TITLE
Fix artalk.js darkmode error

### DIFF
--- a/assets/js/lib/artalk.js
+++ b/assets/js/lib/artalk.js
@@ -3,9 +3,10 @@ import Artalk from 'artalk'
 if (window.config?.comment) {
   const config = window.config.comment.artalk
   if (config) {
-    Artalk.init(config)
+    const artalk =  Artalk.init(config)
+    artalk.setDarkMode(window.isDark)
     window._artalkOnSwitchTheme = () => {
-      Artalk.setDarkMode(window.isDark)
+       artalk.setDarkMode(window.isDark)
     }
     window.switchThemeEventSet.add(window._artalkOnSwitchTheme)
   }


### PR DESCRIPTION
2 week age : bump artalk from 2.6.4 to 2.7.3 #1145 

The upgrade caused an error in the dark mode switch

Reason: Artalk v2.7.0 have BREAKING CHANGE
https://github.com/ArtalkJS/Artalk/releases/tag/v2.7.0 



