### PR TITLE
fix: relref shortcodes (hugo v0.123.0)

### DIFF
--- a/exampleSite/content/posts/how-to-DoIt/create-diagrams/index.en.md
+++ b/exampleSite/content/posts/how-to-DoIt/create-diagrams/index.en.md
@@ -30,7 +30,7 @@ code:
 {{< admonition type=note title="Note" open=true >}}
 Hugo [**v0.93.0**](https://github.com/gohugoio/hugo/releases/tag/v0.93.0) or later is required for drawing custom diagrams.
 
-Check out the [`mermaid` shortcode]({{< relref "../../theme-documentation-extended-shortcodes/index.en.md/#5-mermaid" >}}) if you have to use an older version of Hugo.
+Check out the [`mermaid` shortcode]({{< relref "../../theme-documentation-extended-shortcodes/index.en.md#mermaid" >}}) if you have to use an older version of Hugo.
 {{< /admonition >}}
 
 ## GoAT

--- a/exampleSite/content/posts/how-to-DoIt/create-diagrams/index.zh-cn.md
+++ b/exampleSite/content/posts/how-to-DoIt/create-diagrams/index.zh-cn.md
@@ -30,7 +30,7 @@ code:
 {{< admonition type=note title="Note" open=true >}}
 你需要使用 Hugo [**v0.93.0**](https://github.com/gohugoio/hugo/releases/tag/v0.93.0) 或更新的版本来创建自定义图表。
 
-如果你不得不使用旧版的 Hugo，你可以使用 [`mermaid` shortcode]({{< relref "../../theme-documentation-extended-shortcodes/index.zh-cn.md/#5-mermaid" >}})。
+如果你不得不使用旧版的 Hugo，你可以使用 [`mermaid` shortcode]({{< relref "../../theme-documentation-extended-shortcodes/index.zh-cn.md#mermaid" >}})。
 {{< /admonition >}}
 
 ## GoAT


### PR DESCRIPTION
When running the example site with newly released hugo version v0.123.0 does not succeed, errors are thrown:

```
ERROR [en] REF_NOT_FOUND: Ref "../../theme-documentation-extended-shortcodes/index.en.md/": "/home/andreas/DoIt/exampleSite/content/posts/how-to-DoIt/create-diagrams/index.en.md:1:1": page not found
ERROR [zh-cn] REF_NOT_FOUND: Ref "../../theme-documentation-extended-shortcodes/index.zh-cn.md/": "/home/andreas/DoIt/exampleSite/content/posts/how-to-DoIt/create-diagrams/index.zh-cn.md:1:1": page not found
```

This PR fixes these issues.