### PR TITLE
Disable Bilibili Autoplay

### DIFF
--- a/layouts/shortcodes/bilibili.html
+++ b/layouts/shortcodes/bilibili.html
@@ -1,7 +1,7 @@
 <div class="bilibili">
     {{- if .IsNamedParams -}}
-        <iframe src="//player.bilibili.com/player.html?bvid={{ .Get `id` }}&page={{ .Get `p` | default 1 }}" scrolling="no" border="0" frameborder="no" framespacing="0" allowfullscreen="true"></iframe>
+        <iframe src="//player.bilibili.com/player.html?bvid={{ .Get `id` }}&page={{ .Get `p` | default 1 }}&autoplay=0" scrolling="no" border="0" frameborder="no" framespacing="0" allowfullscreen="true"></iframe>
     {{- else -}}
-        <iframe src="//player.bilibili.com/player.html?bvid={{ .Get 0 }}&page={{ .Get 1 | default 1 }}" scrolling="no" border="0" frameborder="no" framespacing="0" allowfullscreen="true"></iframe>
+        <iframe src="//player.bilibili.com/player.html?bvid={{ .Get 0 }}&page={{ .Get 1 | default 1 }}&autoplay=0" scrolling="no" border="0" frameborder="no" framespacing="0" allowfullscreen="true"></iframe>
     {{- end -}}
 </div>


### PR DESCRIPTION
This PR restores a behavior of the Bilibili iframe player where videos should not autoplay by default. Previously, videos would only play when the user explicitly clicked the play button. However, this is no longer the case, and by default, videos will autoplay. I believe many of us who have checked the [DoIt's extended shortcode post](https://hugodoit.pages.dev/theme-documentation-extended-shortcodes/) have experienced the annoyance of the two Bilibili videos that autoplay on their own, even if we haven't scrolled to those two Bilibili iframe players.

I suspect this is because Bilibili wants to boost their sales (see the comment in this [link](https://blog.zezeshe.com/archives/use-bilibili-iframe-player.html)). Fortunately, this behavior can be disabled by adding `autoplay=0` to the URL.

For now, this PR simply hard-codes `autoplay=0`, but based on [this post](https://blog.zezeshe.com/archives/use-bilibili-iframe-player.html), we can improve the existing Bilibili shortcode to make it more configurable. I can attempt to bring another PR for this improvement.