### PR TITLE
Revert max header icon dimensions to 32x32

### DIFF
--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -5,7 +5,7 @@
             <a href="{{ .Site.Home.RelPermalink }}" title="{{ .Site.Title }}">
                 {{- with .Site.Params.header.title -}}
                 {{- with .logo -}}
-                {{- dict "Src" . "Class" "tw-inline tw-align-text-bottom tw-mr-1" "Height" "28" "Width" "28" | partial "plugin/image.html" -}} {{- end -}}
+                {{- dict "Src" . "Class" "tw-inline tw-align-text-bottom tw-mr-1" "Height" "32" "Width" "32" | partial "plugin/image.html" -}} {{- end -}}
                 {{- with .pre -}}
                 <span class="tw-mr-1">{{ . | safeHTML }}</span>
                 {{- end -}}
@@ -108,7 +108,7 @@
                 <a href="{{ .Site.Home.RelPermalink }}" title="{{ .Site.Title }}">
                     {{- with .Site.Params.header.title -}}
                     {{- with .logo -}}
-                    {{- dict "Src" . "Class" "tw-inline tw-align-text-bottom tw-mr-1" "Height" "28" "Width" "28" | partial "plugin/image.html" -}}
+                    {{- dict "Src" . "Class" "tw-inline tw-align-text-bottom tw-mr-1" "Height" "32" "Width" "32" | partial "plugin/image.html" -}}
                     {{- end -}}
                     {{- with .pre -}}
                     <span class="tw-mr-1">{{ . | safeHTML }}</span>


### PR DESCRIPTION
Follow up of https://github.com/HEIGE-PCloud/DoIt/issues/1289

This change allows the maximum header icon dimensions to match the height of the header text.

## New

![337155715-d4d72f31-0b32-496d-b764-2eec394c2b70](https://github.com/HEIGE-PCloud/DoIt/assets/8585557/0b35d426-0cb6-431c-b7ad-eb319b78a860)

## Old

![337155143-f79c8fd2-a26e-45fb-9ee4-5505a0caf133](https://github.com/HEIGE-PCloud/DoIt/assets/8585557/70adbc7b-d34a-4d65-9cc5-9515553e1d0a)
