### PR TITLE
fix(i18n): Update ko.toml

### DIFF
--- a/i18n/ko.toml
+++ b/i18n/ko.toml
@@ -134,8 +134,8 @@ one = "한 단어"
 other = "{{ .Count }} 단어"
 
 [readingTime]
-one = "읽는데 약 1분"
-other = "읽는데 약 {{ .Count }}분"
+one = "읽는 데 약 1분"
+other = "읽는 데 약 {{ .Count }}분"
 
 [views]
 other = "조회"


### PR DESCRIPTION
### Work Summary
I have corrected the spacing based on Korean spelling rules.  

### Rationale
In the given context, "데" is a dependent noun meaning "thing," "case," or "place." Therefore, it must be separated from the preceding attributive form for correct usage according to Korean grammar rules.  

- Example: "그 책을 다 읽는 데 삼 일이 걸렸다."

---

### 작업 내용
한국어 맞춤법 규정에 따라 띄어쓰기를 수정하였습니다.  

### 근거
여기서 사용된 '데'는 '일', '경우', '장소'를 의미하는 의존명사입니다. 따라서 앞에 오는 관형사형 어미와 띄어 써야 맞는 표현입니다.  

- 예시: "그 책을 다 읽는 데 삼 일이 걸렸다."  