### PR TITLE
feat: add support for reaction option and improve texRenderer option in waline

### DIFF
--- a/assets/js/lib/waline.js
+++ b/assets/js/lib/waline.js
@@ -1,5 +1,18 @@
 import { init } from "@waline/client";
 
 if (window.config?.comment?.waline) {
-  init(window.config.comment.waline);
+  let { texRenderer } = window.config.comment.waline;
+  if (texRenderer) {
+    if (window.katex?.renderToString) {
+      texRenderer = (blockMode, tex) =>
+        window.katex.renderToString(tex, {
+          displayMode: blockMode,
+          throwOnError: false,
+        });
+    } else if (window.MathJax?.tex2mml) {
+      texRenderer = (blockMode, tex) =>
+        window.MathJax.tex2mml(tex, { display: blockMode });
+    }
+  }
+  init({ ...window.config.comment.waline, texRenderer });
 }

--- a/layouts/partials/comment.html
+++ b/layouts/partials/comment.html
@@ -113,6 +113,9 @@
             {{- if eq $waline.texRenderer false -}}
                 {{- $commentConfig = dict "texRenderer" false | dict "waline" | merge $commentConfig -}}
             {{- end -}}
+            {{- if eq $waline.reaction false -}}
+                {{- $commentConfig = dict "reaction" false | dict "waline" | merge $commentConfig -}}
+            {{- end -}}
             {{- $shims := dict "@waline/client" "js/shims/waline.js" -}}
             {{- $options := dict -}}
             {{- $source := $cdn.walineJS | default "lib/waline/waline.js" -}}

--- a/layouts/partials/comment.html
+++ b/layouts/partials/comment.html
@@ -113,8 +113,8 @@
             {{- with $waline.texRenderer | or (eq $waline.texRenderer false) -}}
                 {{- $commentConfig = dict "texRenderer" $waline.texRenderer | dict "waline" | merge $commentConfig -}}
             {{- end -}}
-            {{- if eq $waline.reaction false -}}
-                {{- $commentConfig = dict "reaction" false | dict "waline" | merge $commentConfig -}}
+            {{- with $waline.reaction | or (eq $waline.reaction false) -}}
+                {{- $commentConfig = dict "reaction" $waline.reaction | dict "waline" | merge $commentConfig -}}
             {{- end -}}
             {{- $shims := dict "@waline/client" "js/shims/waline.js" -}}
             {{- $options := dict -}}

--- a/layouts/partials/comment.html
+++ b/layouts/partials/comment.html
@@ -110,8 +110,8 @@
             {{- if eq $waline.highlighter false -}}
                 {{- $commentConfig = dict "highlighter" false | dict "waline" | merge $commentConfig -}}
             {{- end -}}
-            {{- if eq $waline.texRenderer false -}}
-                {{- $commentConfig = dict "texRenderer" false | dict "waline" | merge $commentConfig -}}
+            {{- with $waline.texRenderer | or (eq $waline.texRenderer false) -}}
+                {{- $commentConfig = dict "texRenderer" $waline.texRenderer | dict "waline" | merge $commentConfig -}}
             {{- end -}}
             {{- if eq $waline.reaction false -}}
                 {{- $commentConfig = dict "reaction" false | dict "waline" | merge $commentConfig -}}

--- a/layouts/partials/comment.html
+++ b/layouts/partials/comment.html
@@ -110,10 +110,10 @@
             {{- if eq $waline.highlighter false -}}
                 {{- $commentConfig = dict "highlighter" false | dict "waline" | merge $commentConfig -}}
             {{- end -}}
-            {{- with $waline.texRenderer | or (eq $waline.texRenderer false) -}}
+            {{- if isset $waline "texrenderer" -}}
                 {{- $commentConfig = dict "texRenderer" $waline.texRenderer | dict "waline" | merge $commentConfig -}}
             {{- end -}}
-            {{- with $waline.reaction | or (eq $waline.reaction false) -}}
+            {{- if isset $waline "reaction" -}}
                 {{- $commentConfig = dict "reaction" $waline.reaction | dict "waline" | merge $commentConfig -}}
             {{- end -}}
             {{- $shims := dict "@waline/client" "js/shims/waline.js" -}}


### PR DESCRIPTION
- Add support for reaction option.
- Support formulas in preview by using the global math renderer when texRenderer is set to true.

References:
- https://waline.js.org/en/reference/client/props.html#reaction
- https://waline.js.org/en/reference/client/props.html#texrenderer
- https://waline.js.org/en/cookbook/customize/tex-renderer.html