### PR TITLE
Fix error 'failed to resolve media type'

### DIFF
--- a/exampleSite/content/posts/basic-markdown-syntax/index.en.md
+++ b/exampleSite/content/posts/basic-markdown-syntax/index.en.md
@@ -834,10 +834,10 @@ Images have a similar syntax to links but include a preceding exclamation point.
 or:
 
 ```markdown
-![Alt text](https://octodex.github.com/images/stormtroopocat.jpg "The Stormtroopocat")
+![Alt text](https://octodex.github.com/images/stormtroopocat.png "The Stormtroopocat")
 ```
 
-![Alt text](https://octodex.github.com/images/stormtroopocat.jpg "The Stormtroopocat")
+![Alt text](https://octodex.github.com/images/stormtroopocat.png "The Stormtroopocat")
 
 Like links, images also have a footnote style syntax:
 

--- a/exampleSite/content/posts/basic-markdown-syntax/index.zh-cn.md
+++ b/exampleSite/content/posts/basic-markdown-syntax/index.zh-cn.md
@@ -841,10 +841,10 @@ Content for chapter one.
 或者:
 
 ```markdown
-![Alt text](https://octodex.github.com/images/stormtroopocat.jpg "The Stormtroopocat")
+![Alt text](https://octodex.github.com/images/stormtroopocat.png "The Stormtroopocat")
 ```
 
-![Alt text](https://octodex.github.com/images/stormtroopocat.jpg "The Stormtroopocat")
+![Alt text](https://octodex.github.com/images/stormtroopocat.png "The Stormtroopocat")
 
 像链接一样, 图片也具有脚注样式的语法:
 

--- a/exampleSite/content/posts/tests/markdown-tests/index.en.md
+++ b/exampleSite/content/posts/tests/markdown-tests/index.en.md
@@ -172,4 +172,4 @@ This is a footnote with "label"[^label]
 
 ![Minion](https://octodex.github.com/images/minion.png)
 
-![Alt text](https://octodex.github.com/images/stormtroopocat.jpg "The Stormtroopocat")
+![Alt text](https://octodex.github.com/images/stormtroopocat.png "The Stormtroopocat")


### PR DESCRIPTION
When previewing the example site, an error is reported:

```
WARN  template: _partials/plugin/image.html:42:27: executing "_partials/plugin/image.html" at <resources.GetRemote>:
error calling GetRemote: failed to resolve media type for remote resource "https://octodex.github.com/images/stormtroopocat.jpg"
```

This PR fixes that error.