### PR TITLE
Discard deprecated libsass transpiler, use dartsass instead

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,6 +18,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Install Dart Sass # Installs dart-sass
+        run: sudo snap install dart-sass --edge
+      
       - name: Hugo setup
         uses: peaceiris/actions-hugo@v3
         with:
@@ -26,7 +29,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: "16"
+          node-version: "24"
 
       - name: Install dependencies
         run: npm install

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -20,6 +20,9 @@ jobs:
     - name: Set up Homebrew
       uses: Homebrew/actions/setup-homebrew@master
 
+    - name: Install Dart Sass # Installs dart-sass
+      run: brew install sass/sass/sass
+      
     - name: Hugo setup
       run: brew install hugo
 

--- a/assets/css/_core/_base.scss
+++ b/assets/css/_core/_base.scss
@@ -1,3 +1,12 @@
+@use "_mixin/_compatibility" as compat;
+@use "_mixin/_link";
+@use "_variables" as var;
+
+@use "_partial/mask";
+@use "_partial/icon";
+@use "_partial/details";
+@use "_partial/cookieconsent";
+
 /* Opt-in the whole page to interpolate sizes to/from keywords */
 // https://developer.chrome.com/docs/css-ui/animate-to-height-auto
 :root {
@@ -5,11 +14,11 @@
 }
 
 html {
-  font-family: $global-font-family;
-  font-weight: $global-font-weight;
+  font-family: var.$global-font-family;
+  font-weight: var.$global-font-weight;
   font-display: swap;
-  font-size: $global-font-size;
-  line-height: $global-line-height;
+  font-size: var.$global-font-size;
+  line-height: var.$global-line-height;
   width: 100%;
   scroll-behavior: smooth;
   overflow: overlay;
@@ -22,23 +31,18 @@ html {
 }
 
 ::selection {
-  background-color: $selection-color;
+  background-color: var.$selection-color;
 }
 
 body {
-  background-color: $global-background-color;
-  color: $global-font-color;
-  @include overflow-wrap(break-word);
+  background-color: var.$global-background-color;
+  color: var.$global-font-color;
+  @include compat.overflow-wrap(break-word);
   scrollbar-color: auto;
 }
 
-@include ms;
-@include link(true, true);
-
-@import "../_partial/mask";
-@import "../_partial/icon";
-@import "../_partial/details";
-@import "../_partial/cookieconsent";
+@include compat.ms;
+@include link.link(true, true);
 
 img {
   object-fit: cover;

--- a/assets/css/_core/_media.scss
+++ b/assets/css/_core/_media.scss
@@ -1,3 +1,5 @@
+@use "_variables" as var;
+
 @media only screen and (max-width: 1440px) {
   .page {
     width: 56%;
@@ -63,7 +65,7 @@
   .page {
     width: 100% !important;
     margin-left: auto !important;
-    padding-top: $header-height;
+    padding-top: var.$header-height;
 
     .categories-card,
     .author-card,

--- a/assets/css/_mixin/_blur.scss
+++ b/assets/css/_mixin/_blur.scss
@@ -1,5 +1,7 @@
+@use "./_compatibility" as compat;
+
 @mixin blur {
   .blur & {
-    @include filter(blur(1.5px));
+    @include compat.filter(blur(1.5px));
   }
 }

--- a/assets/css/_mixin/_index.scss
+++ b/assets/css/_mixin/_index.scss
@@ -1,3 +1,3 @@
-@import "_compatibility";
-@import "_link";
-@import "_blur";
+@use "_compatibility";
+@use "./_link";
+@use "_blur";

--- a/assets/css/_mixin/_link.scss
+++ b/assets/css/_mixin/_link.scss
@@ -1,20 +1,22 @@
+@use "_variables" as var;
+
 @mixin link($light, $dark) {
   a,
   a::before,
   a::after {
     text-decoration: none;
 
-    color: if($light, $global-link-color, $single-link-color);
+    color: if($light, var.$global-link-color, var.$single-link-color);
     .dark & {
-      color: if($dark, $global-link-color, $single-link-color);
+      color: if($dark, var.$global-link-color, var.$single-link-color);
     }
   }
 
   a:active,
   a:hover {
-    color: if($light, $global-link-hover-color, $single-link-hover-color);
+    color: if($light, var.$global-link-hover-color, var.$single-link-hover-color);
     .dark & {
-      color: if($dark, $global-link-hover-color, $single-link-hover-color);
+      color: if($dark, var.$global-link-hover-color, var.$single-link-hover-color);
     }
   }
 }

--- a/assets/css/_page/_archive.scss
+++ b/assets/css/_page/_archive.scss
@@ -1,3 +1,6 @@
+@use "_partial/_archive/terms";
+@use "_partial/_archive/tags";
+
 .archive {
   .single-title {
     text-align: right;
@@ -11,6 +14,4 @@
     padding-top: 0.5rem;
     font-size: 1.5rem;
   }
-  @import "../_partial/_archive/terms";
-  @import "../_partial/_archive/tags";
 }

--- a/assets/css/_page/_home.scss
+++ b/assets/css/_page/_home.scss
@@ -1,6 +1,10 @@
+@use "_mixin/_compatibility" as compat;
+@use "_mixin/_link";
+@use "_variables" as var;
+
 .home {
   .home-profile {
-    @include transform(translateY(16vh));
+    @include compat.transform(translateY(16vh));
     padding: 0 0 0.5rem;
     text-align: center;
 
@@ -12,13 +16,13 @@
         width: 8rem;
         height: auto;
         margin: 0 auto;
-        @include border-radius(100%);
-        @include box-shadow(0 0 0 0.3618em rgba(0, 0, 0, 0.05));
-        @include transition(all 0.4s ease);
+        @include compat.border-radius(100%);
+        @include compat.box-shadow(0 0 0 0.3618em rgba(0, 0, 0, 0.05));
+        @include compat.transition(all 0.4s ease);
 
         &:hover {
           position: relative;
-          @include transform(translateY(-0.75rem));
+          @include compat.transform(translateY(-0.75rem));
         }
       }
     }
@@ -57,14 +61,14 @@
       font-weight: normal;
       margin: 0;
       padding: 0.5rem;
-      color: $global-font-secondary-color;
+      color: var.$global-font-secondary-color;
     }
   }
 }
 
 .home[posts] {
   .home-profile {
-    @include transform(translateY(0));
+    @include compat.transform(translateY(0));
     padding-top: 2rem;
   }
 
@@ -75,15 +79,15 @@
   .summary {
     padding-top: 1rem;
     padding-bottom: 0.8rem;
-    color: $global-font-color;
-    border-bottom: 3px dashed $global-border-color;
+    color: var.$global-font-color;
+    border-bottom: 3px dashed var.$global-border-color;
 
     .featured-image-preview {
       width: 100%;
       padding: 30% 0 0;
       position: relative;
       margin: 0.6rem auto;
-      @include transition(transform 0.4s ease);
+      @include compat.transition(transform 0.4s ease);
 
       img {
         position: absolute;
@@ -95,7 +99,7 @@
       }
 
       &:hover {
-        @include transform(scale(1.01));
+        @include compat.transform(scale(1.01));
       }
     }
 
@@ -106,13 +110,13 @@
     }
 
     .content {
-      @include box(vertical);
+      @include compat.box(vertical);
       margin-top: 0.3rem;
       width: 100%;
       overflow: hidden;
       text-overflow: ellipsis;
-      @include overflow-wrap(break-word);
-      color: $global-font-secondary-color;
+      @include compat.overflow-wrap(break-word);
+      color: var.$global-font-secondary-color;
 
       h2,
       h3,
@@ -134,11 +138,11 @@
         font-size: 1.125rem;
       }
 
-      @include link(false, true);
+      @include link.link(false, true);
 
       b,
       strong {
-        color: $global-font-secondary-color;
+        color: var.$global-font-secondary-color;
       }
     }
 
@@ -149,12 +153,12 @@
       align-items: center;
       font-size: 0.875rem;
 
-      @include link(false, false);
+      @include link.link(false, false);
 
       .post-tags {
         padding: 0;
 
-        @include link(true, true);
+        @include link.link(true, true);
       }
     }
   }

--- a/assets/css/_page/_index.scss
+++ b/assets/css/_page/_index.scss
@@ -1,15 +1,18 @@
+@use "_mixin/blur";
+@use "_variables" as var;
+
+@use "_single";
+@use "_special";
+@use "_archive";
+@use "_home";
+@use "_taxonomy";
+
 .page {
   position: relative;
   max-width: 800px;
   width: 60%;
   margin: 0 auto;
-  padding-top: $header-height;
+  padding-top: var.$header-height;
 
-  @include blur;
+  @include blur.blur;
 }
-
-@import "_single";
-@import "_special";
-@import "_archive";
-@import "_home";
-@import "_taxonomy";

--- a/assets/css/_page/_single.scss
+++ b/assets/css/_page/_single.scss
@@ -198,7 +198,7 @@
           cursor: pointer;
         }
 
-        th[role="columnheader"]:not(.no-sort):after {
+        th[role="columnheader"]:not(.no-sort)::after {
           content: "";
           float: right;
           margin: 0.7rem -0.5rem 0px 0.5rem;
@@ -214,17 +214,17 @@
           user-select: none;
         }
 
-        th[aria-sort="ascending"]:not(.no-sort):after {
+        th[aria-sort="ascending"]:not(.no-sort)::after {
           border-bottom: none;
           border-width: 4px 4px 0;
         }
 
-        th[aria-sort]:not(.no-sort):after {
+        th[aria-sort]:not(.no-sort)::after {
           visibility: visible;
           opacity: 0.4;
         }
 
-        th[role="columnheader"]:not(.no-sort):hover:after {
+        th[role="columnheader"]:not(.no-sort):hover::after {
           visibility: visible;
           opacity: 1;
         }

--- a/assets/css/_page/_single.scss
+++ b/assets/css/_page/_single.scss
@@ -1,5 +1,24 @@
-@import "../_partial/_single/series";
-@import "../_partial/_single/toc";
+@use "_mixin/_compatibility" as compat;
+@use "_mixin/_link";
+@use "_variables" as var;
+
+@use "_partial/_single/series";
+@use "_partial/_single/toc";
+
+@use "_partial/_single/code";
+@use "_partial/_single/katex";
+@use "_partial/_single/admonition";
+@use "_partial/_single/echarts";
+@use "_partial/_single/mapbox";
+@use "_partial/_single/music";
+@use "_partial/_single/bilibili";
+@use "_partial/_single/friend";
+@use "_partial/_single/showcase";
+@use "_partial/_single/mermaid";
+
+@use "_partial/_single/footer";
+@use "_partial/_single/sponsor";
+@use "_partial/_single/related";
 
 .single {
   .single-title {
@@ -19,13 +38,13 @@
 
   .post-meta {
     font-size: 0.875rem;
-    color: $global-font-secondary-color;
+    color: var.$global-font-secondary-color;
 
     span {
       display: inline-block;
     }
 
-    @include link(false, true);
+    @include link.link(false, true);
 
     .author {
       font-size: 1.05rem;
@@ -83,7 +102,7 @@
     h4,
     h5,
     h6 {
-      font-weight: $single-h-font-weight;
+      font-weight: var.$single-h-font-weight;
       margin: 1.2rem 0;
     }
 
@@ -95,7 +114,7 @@
       > .header-mark::before {
         content: "|";
         margin-right: 0.3125rem;
-        color: $single-link-color;
+        color: var.$single-link-color;
       }
     }
 
@@ -110,23 +129,23 @@
     b,
     strong {
       font-weight: bold;
-      color: $single-content-strong-color;
+      color: var.$single-content-strong-color;
     }
 
-    @include link(false, false);
+    @include link.link(false, false);
 
     a {
-      @include overflow-wrap(break-word);
+      @include compat.overflow-wrap(break-word);
 
       & b,
       & strong {
-        color: $single-link-color;
+        color: var.$single-link-color;
       }
     }
 
     a:hover b,
     a:hover strong {
-      color: $single-link-hover-color;
+      color: var.$single-link-hover-color;
     }
 
     ul,
@@ -140,10 +159,10 @@
     }
 
     ruby {
-      background: $code-background-color;
+      background: var.$code-background-color;
 
       rt {
-        color: $global-font-secondary-color;
+        color: var.$global-font-secondary-color;
       }
     }
 
@@ -155,11 +174,11 @@
         max-width: 100%;
         margin: 0.625rem 0;
         border-spacing: 0;
-        background: $table-background-color;
+        background: var.$table-background-color;
         border-collapse: collapse;
 
         thead {
-          background: $table-thead-color;
+          background: var.$table-thead-color;
         }
 
         td:nth-child(2).lntd {
@@ -172,7 +191,7 @@
         th,
         td {
           padding: 0.3rem 1rem;
-          border: 1px solid $table-border-color;
+          border: 1px solid var.$table-border-color;
         }
 
         th[role="columnheader"]:not(.no-sort) {
@@ -185,7 +204,7 @@
           margin: 0.7rem -0.5rem 0px 0.5rem;
           border-width: 0 4px 4px;
           border-style: solid;
-          border-color: $global-font-color transparent;
+          border-color: var.$global-font-color transparent;
 
           visibility: hidden;
           opacity: 0;
@@ -241,14 +260,14 @@
 
     blockquote {
       display: block;
-      border-left: 0.25rem solid $blockquote-color;
-      background-color: $blockquote-bg-color;
+      border-left: 0.25rem solid var.$blockquote-color;
+      background-color: var.$blockquote-bg-color;
       padding: 0.25rem 0.75rem;
       margin: 1rem 0;
     }
 
     .footnotes {
-      color: $global-font-secondary-color;
+      color: var.$global-font-secondary-color;
 
       p {
         margin: 0.25rem 0;
@@ -268,35 +287,24 @@
       scroll-margin-top: 3.5rem;
     }
 
-    @import "../_partial/_single/code";
-    @import "../_partial/_single/katex";
-    @import "../_partial/_single/admonition";
-    @import "../_partial/_single/echarts";
-    @import "../_partial/_single/mapbox";
-    @import "../_partial/_single/music";
-    @import "../_partial/_single/bilibili";
-    @import "../_partial/_single/friend";
-    @import "../_partial/_single/showcase";
-    @import "../_partial/_single/mermaid";
-
     hr {
       margin: 2rem 0;
       position: relative;
-      border-top: 3px dashed $global-border-color;
+      border-top: 3px dashed var.$global-border-color;
       border-bottom: none;
     }
 
     kbd {
       display: inline-block;
       padding: 0.25rem;
-      background-color: $global-background-color;
-      border: 1px solid $global-border-color;
-      border-bottom-color: $global-border-color;
-      @include border-radius(3px);
-      @include box-shadow(inset 0 -1px 0 $global-border-color);
+      background-color: var.$global-background-color;
+      border: 1px solid var.$global-border-color;
+      border-bottom-color: var.$global-border-color;
+      @include compat.border-radius(3px);
+      @include compat.box-shadow(inset 0 -1px 0 var.$global-border-color);
       font-size: 0.8rem;
-      font-family: $code-font-family;
-      color: $code-color;
+      font-family: var.$code-font-family;
+      color: var.$code-color;
     }
 
     .version {
@@ -305,26 +313,22 @@
       vertical-align: text-bottom;
     }
   }
-
-  @import "../_partial/_single/footer";
-  @import "../_partial/_single/sponsor";
-  @import "../_partial/_single/related";
 }
 
 .typeit {
   .highlight {
     padding: 0.375rem;
     font-size: 0.875rem;
-    font-family: $code-font-family;
+    font-family: var.$code-font-family;
     word-break: break-all;
     white-space: pre-wrap;
   }
 
-  --ti-cursor-font-family: #{$global-font-family};
-  --ti-cursor-font-size: #{$global-font-size};
-  --ti-cursor-font-weight: #{$global-font-weight};
-  --ti-cursor-line-height: #{$global-line-height};
-  --ti-cursor-color: #{$global-font-secondary-color};
+  --ti-cursor-font-family: #{var.$global-font-family};
+  --ti-cursor-font-size: #{var.$global-font-size};
+  --ti-cursor-font-weight: #{var.$global-font-weight};
+  --ti-cursor-line-height: #{var.$global-line-height};
+  --ti-cursor-color: #{var.$global-font-secondary-color};
   --ti-cursor-margin-left: 0;
 }
 

--- a/assets/css/_page/_taxonomy.scss
+++ b/assets/css/_page/_taxonomy.scss
@@ -1,7 +1,9 @@
+@use "_variables" as var;
+
 .introduction blockquote {
   display: block;
-  border-left: 0.25rem solid $blockquote-color;
-  background-color: $blockquote-bg-color;
+  border-left: 0.25rem solid var.$blockquote-color;
+  background-color: var.$blockquote-bg-color;
   padding: 0.25rem 0.75rem;
   margin: 1rem 0;
 }

--- a/assets/css/_partial/_archive/_tags.scss
+++ b/assets/css/_partial/_archive/_tags.scss
@@ -1,23 +1,27 @@
+@use "_mixin/_link";
+@use "_mixin/_compatibility" as compat;
+@use "_variables" as var;
+
 .tag-cloud-tags {
   margin: 10px 0;
 
-  @include link(true, true);
+  @include link.link(true, true);
 
   a {
     display: inline-block;
     position: relative;
     margin: 5px 10px;
-    @include overflow-wrap(break-word);
-    @include transition(all ease-out 0.3s);
+    @include compat.overflow-wrap(break-word);
+    @include compat.transition(all ease-out 0.3s);
 
     &:active,
     &:focus,
     &:hover {
-      @include transform(scale(1.2));
+      @include compat.transform(scale(1.2));
     }
 
     sup {
-      color: $global-font-secondary-color;
+      color: var.$global-font-secondary-color;
     }
   }
 }

--- a/assets/css/_partial/_archive/_terms.scss
+++ b/assets/css/_partial/_archive/_terms.scss
@@ -1,3 +1,5 @@
+@use "_variables" as var;
+
 .categories-card,
 .author-card,
 .series-card {
@@ -56,17 +58,17 @@
   overflow: hidden;
   text-overflow: ellipsis;
 
-  color: $global-link-color;
+  color: var.$global-link-color;
 
   &:hover {
-    color: $global-link-hover-color;
+    color: var.$global-link-hover-color;
     background-color: transparent;
   }
 }
 
 .archive-item-date {
   text-align: right;
-  color: $global-font-secondary-color;
+  color: var.$global-font-secondary-color;
   font-variant-numeric: tabular-nums;
   min-width: fit-content;
   margin-left: auto;

--- a/assets/css/_partial/_cookieconsent.scss
+++ b/assets/css/_partial/_cookieconsent.scss
@@ -1,10 +1,12 @@
+@use "_variables" as var;
+
 .cc-window.cc-banner {
   .cc-btn {
-    color: $global-font-color;
+    color: var.$global-font-color;
 
     &:hover,
     &:focus {
-      background-color: $cookie-background-color;
+      background-color: var.$cookie-background-color;
     }
   }
 }

--- a/assets/css/_partial/_details.scss
+++ b/assets/css/_partial/_details.scss
@@ -1,3 +1,6 @@
+@use "_variables" as var;
+@use "_mixin/_compatibility" as compat;
+
 .details {
   .details-summary {
     &:hover {
@@ -6,8 +9,8 @@
   }
 
   .details-icon > svg {
-    color: $global-font-secondary-color;
-    @include transition(transform 0.2s ease);
+    color: var.$global-font-secondary-color;
+    @include compat.transition(transform 0.2s ease);
   }
 
   .details-content {
@@ -18,7 +21,7 @@
 
   &.open {
     .details-icon > svg {
-      @include transform(rotate(90deg));
+      @include compat.transform(rotate(90deg));
     }
 
     .details-content {

--- a/assets/css/_partial/_footer.scss
+++ b/assets/css/_partial/_footer.scss
@@ -1,3 +1,5 @@
+@use "_mixin/_blur";
+
 footer {
   height: fit-content;
   width: 100%;
@@ -17,5 +19,5 @@ footer {
     }
   }
 
-  @include blur;
+  @include blur.blur;
 }

--- a/assets/css/_partial/_header.scss
+++ b/assets/css/_partial/_header.scss
@@ -1,11 +1,16 @@
+@use "_mixin/_compatibility" as compat;
+@use "_mixin/_link";
+@use "_variables" as var;
+@use "sass:math";
+
 header {
   width: 100%;
   z-index: 150;
-  background-color: $header-background-color;
-  @include transition(box-shadow 0.3s ease);
+  background-color: var.$header-background-color;
+  @include compat.transition(box-shadow 0.3s ease);
 
   &:hover {
-    @include box-shadow(0 0 1.5rem 0 rgba(0, 0, 0, 0.1));
+    @include compat.box-shadow(0 0 1.5rem 0 rgba(0, 0, 0, 0.1));
   }
 }
 
@@ -18,14 +23,14 @@ header {
 }
 
 .header-title {
-  font-family: $header-title-font-family;
+  font-family: var.$header-title-font-family;
   font-weight: bold;
   margin-right: 0.5rem;
   min-width: 10%;
   overflow: hidden;
   white-space: nowrap;
   text-overflow: ellipsis;
-  @include flex(10);
+  @include compat.flex(10);
 }
 
 .menu .menu-item {
@@ -66,15 +71,15 @@ header {
     box-sizing: border-box;
     height: 2.5rem;
     width: 2.5rem;
-    @include border-radius(0.5rem);
+    @include compat.border-radius(0.5rem);
     border: none;
     outline: none;
-    background-color: $header-background-color;
+    background-color: var.$header-background-color;
     vertical-align: baseline !important;
-    @include transition(width 0.3s ease);
+    @include compat.transition(width 0.3s ease);
   }
 
-  @include placeholder(transparent);
+  @include compat.placeholder(transparent);
 
   .search-button {
     margin: 0;
@@ -102,15 +107,15 @@ header {
   .open &,
   &.mobile {
     input {
-      color: $global-font-color;
-      background-color: $search-background-color;
+      color: var.$global-font-color;
+      background-color: var.$search-background-color;
       padding: 0 2rem 0 2rem;
     }
 
-    @include placeholder($global-font-secondary-color);
+    @include compat.placeholder(var.$global-font-secondary-color);
 
     .search-button {
-      color: $global-font-secondary-color;
+      color: var.$global-font-secondary-color;
     }
 
     .search-clear:hover {
@@ -124,24 +129,24 @@ header {
 }
 
 .theme-switch svg {
-  @include transform(rotate(225deg));
+  @include compat.transform(rotate(225deg));
 }
 
 .theme-select svg {
-  @include transform(rotate(225deg));
+  @include compat.transform(rotate(225deg));
 }
 
 #header-desktop {
   display: block;
   position: fixed;
-  height: $header-height;
-  line-height: $header-height;
+  height: var.$header-height;
+  line-height: var.$header-height;
 
   .header-wrapper {
     padding: 0 2rem 0 10%;
 
     .header-title {
-      font-size: $header-title-font-size;
+      font-size: var.$header-title-font-size;
     }
 
     .menu {
@@ -156,8 +161,8 @@ header {
         margin: 0 0.5rem;
 
         &.delimiter {
-          border-left: 1.5px solid $global-font-color;
-          border-left-color: $header-delimiter;
+          border-left: 1.5px solid var.$global-font-color;
+          border-left-color: var.$header-delimiter;
         }
 
         &.language {
@@ -175,7 +180,7 @@ header {
 
       a.active {
         font-weight: 900;
-        color: $header-hover-color;
+        color: var.$header-hover-color;
       }
     }
   }
@@ -192,8 +197,8 @@ header {
 #header-mobile {
   display: none;
   position: fixed;
-  height: $header-height;
-  line-height: $header-height;
+  height: var.$header-height;
+  line-height: var.$header-height;
 
   .header-container {
     padding: 0;
@@ -202,25 +207,25 @@ header {
     .header-wrapper {
       padding: 0 1rem;
       font-size: 1.125rem;
-      @include transition(margin-top 0.3s ease);
+      @include compat.transition(margin-top 0.3s ease);
 
       .header-title {
-        font-size: $header-title-font-size;
+        font-size: var.$header-title-font-size;
         max-width: 80%;
       }
 
       .menu-toggle {
         line-height: 4rem;
         cursor: pointer;
-        @include transition(width 0.3s ease);
+        @include compat.transition(width 0.3s ease);
 
         span {
           display: block;
-          background: $global-font-color;
+          background: var.$global-font-color;
           width: 1.5rem;
           height: 2px;
-          @include border-radius(3px);
-          @include transition(all 0.3s ease-in-out);
+          @include compat.border-radius(3px);
+          @include compat.transition(all 0.3s ease-in-out);
         }
 
         span:nth-child(1) {
@@ -233,7 +238,7 @@ header {
 
         &.active {
           span:nth-child(1) {
-            @include transform(rotate(45deg) translate(0.4rem, 0.5rem));
+            @include compat.transform(rotate(45deg) translate(0.4rem, 0.5rem));
           }
 
           span:nth-child(2) {
@@ -241,7 +246,7 @@ header {
           }
 
           span:nth-child(3) {
-            @include transform(rotate(-45deg) translate(0.4rem, -0.5rem));
+            @include compat.transform(rotate(-45deg) translate(0.4rem, -0.5rem));
           }
         }
       }
@@ -249,18 +254,18 @@ header {
 
     .menu {
       text-align: center;
-      background: $header-background-color;
-      border-top: 2px solid $global-border-color;
+      background: var.$header-background-color;
+      border-top: 2px solid var.$global-border-color;
       display: none;
       padding-top: 0.5rem;
-      @include box-shadow(0 0.125rem 0.25rem rgba(0, 0, 0, 0.1));
+      @include compat.box-shadow(0 0.125rem 0.25rem rgba(0, 0, 0, 0.1));
 
       .search-wrapper {
         display: flex;
         justify-content: space-between;
         align-items: center;
         box-sizing: border-box;
-        padding: ($header-height - 2.5rem) / 2 1rem;
+        padding: math.div((var.$header-height - 2.5rem), 2) 1rem;
         line-height: 2.5rem;
       }
 
@@ -295,7 +300,7 @@ header {
 
   &.open {
     .header-wrapper {
-      margin-top: -$header-height;
+      margin-top: -(var.$header-height);
     }
 
     .menu {
@@ -316,8 +321,8 @@ header {
 .search-dropdown {
   position: fixed;
   z-index: 200;
-  top: $header-height;
-  @include box-shadow(0 0.125rem 0.25rem rgba(0, 0, 0, 0.1));
+  top: var.$header-height;
+  @include compat.box-shadow(0 0.125rem 0.25rem rgba(0, 0, 0, 0.1));
 
   &.desktop {
     right: 2rem;
@@ -331,11 +336,11 @@ header {
 
   .dropdown-menu {
     right: 0 !important;
-    background-color: $global-background-color;
+    background-color: var.$global-background-color;
 
     .suggestions {
       overflow-y: auto;
-      max-height: calc(100vh - #{$header-height});
+      max-height: calc(100vh - #{var.$header-height});
 
       .suggestion {
         padding: 0.75rem 1rem;
@@ -358,26 +363,26 @@ header {
           font-size: 0.875rem;
           float: right;
           text-align: right;
-          color: $global-font-secondary-color;
+          color: var.$global-font-secondary-color;
         }
 
         .suggestion-context {
           line-height: 1.25rem;
-          @include box(vertical);
+          @include compat.box(vertical);
           -webkit-line-clamp: 2;
           overflow: hidden;
           text-overflow: ellipsis;
-          @include overflow-wrap(break-word);
-          color: $global-font-secondary-color;
+          @include compat.overflow-wrap(break-word);
+          color: var.$global-font-secondary-color;
         }
 
         em {
           font-style: normal;
-          background-color: $selection-color;
+          background-color: var.$selection-color;
         }
 
         &.cursor {
-          background: $code-background-color-darken-5;
+          background: var.$code-background-color-darken-5;
         }
 
         &:hover {
@@ -392,7 +397,7 @@ header {
 
       .search-query {
         font-weight: bold;
-        color: $search-empty-font-color;
+        color: var.$search-empty-font-color;
       }
     }
 
@@ -400,9 +405,9 @@ header {
       padding: 0.5rem 1rem;
       float: right;
       font-size: 0.8rem;
-      color: $global-font-secondary-color;
+      color: var.$global-font-secondary-color;
 
-      @include link(false, false);
+      @include link.link(false, false);
 
       a {
         font-size: 1rem;

--- a/assets/css/_partial/_icon.scss
+++ b/assets/css/_partial/_icon.scss
@@ -1,3 +1,5 @@
+@use "_variables" as var;
+
 svg.icon {
   display: inline-block;
   width: 1.25em;
@@ -22,7 +24,7 @@ svg.icon {
   height: 1em;
   width: 1.25em;
   vertical-align: -0.125em;
-  color: $global-font-color default;
+  color: var.$global-font-color default;
 }
 
 svg.icon > path {

--- a/assets/css/_partial/_pagination.scss
+++ b/assets/css/_partial/_pagination.scss
@@ -1,3 +1,6 @@
+@use "_mixin/_compatibility" as compat;
+@use "_variables" as var;
+
 .pagination {
   display: flex;
   flex-direction: row;
@@ -9,12 +12,12 @@
 
   a {
     font-size: 0.8rem;
-    color: $global-font-secondary-color;
+    color: var.$global-font-secondary-color;
     letter-spacing: 0.1rem;
     font-weight: 700;
     padding: 5px 5px;
     text-decoration: none;
-    @include transition(0.3s);
+    @include compat.transition(0.3s);
   }
 
   li {
@@ -29,7 +32,7 @@
     }
 
     &:hover a {
-      color: $pagination-link-hover-color;
+      color: var.$pagination-link-hover-color;
     }
 
     &:before,
@@ -38,8 +41,8 @@
       content: "";
       width: 0;
       height: 3px;
-      background: $pagination-link-hover-color;
-      @include transition(0.3s);
+      background: var.$pagination-link-hover-color;
+      @include compat.transition(0.3s);
       bottom: 0px;
     }
 
@@ -65,7 +68,7 @@
 
     &.active {
       a {
-        color: $pagination-link-hover-color;
+        color: var.$pagination-link-hover-color;
       }
 
       &:before,

--- a/assets/css/_partial/_pagination.scss
+++ b/assets/css/_partial/_pagination.scss
@@ -35,8 +35,8 @@
       color: var.$pagination-link-hover-color;
     }
 
-    &:before,
-    &:after {
+    &::before,
+    &::after {
       position: absolute;
       content: "";
       width: 0;
@@ -46,22 +46,22 @@
       bottom: 0px;
     }
 
-    &:before .active,
-    &:after .active {
+    &::before .active,
+    &::after .active {
       width: 100%;
     }
 
-    &:before {
+    &::before {
       left: 50%;
     }
 
-    &:after {
+    &::after {
       right: 50%;
     }
 
     &:hover {
-      &:before,
-      &:after {
+      &::before,
+      &::after {
         width: 50%;
       }
     }
@@ -71,8 +71,8 @@
         color: var.$pagination-link-hover-color;
       }
 
-      &:before,
-      &:after {
+      &::before,
+      &::after {
         width: 60%;
       }
     }

--- a/assets/css/_partial/_single/_admonition.scss
+++ b/assets/css/_partial/_single/_admonition.scss
@@ -1,24 +1,28 @@
+@use "_variables" as var;
+@use "sass:color";
+@use "sass:map";
+
 .admonition {
   position: relative;
   margin: 1rem 0;
   padding: 0 0.75rem;
-  background-color: map-get($admonition-background-color-map, "note");
-  border-left: 0.25rem solid map-get($admonition-color-map, "note");
+  background-color: map.get(var.$admonition-background-color-map, "note");
+  border-left: 0.25rem solid map.get(var.$admonition-color-map, "note");
   overflow: auto;
 
   .admonition-title {
     font-weight: bold;
     margin: 0 -0.75rem;
     padding: 0.25rem 1.8rem;
-    border-bottom: 1px solid map-get($admonition-background-color-map, "note");
-    background-color: opacify(
-      map-get($admonition-background-color-map, "note"),
-      0.15
+    border-bottom: 1px solid map.get(var.$admonition-background-color-map, "note");
+    background-color: color.adjust(
+      map.get(var.$admonition-background-color-map, "note"),
+      $alpha: -0.15
     );
   }
 
   &.open .admonition-title {
-    background-color: map-get($admonition-background-color-map, "note");
+    background-color: map.get(var.$admonition-background-color-map, "note");
   }
 
   .admonition-content {
@@ -27,7 +31,7 @@
 
   span.icon > svg {
     font-size: 0.85rem;
-    color: map-get($admonition-color-map, "note");
+    color: map.get(var.$admonition-color-map, "note");
     position: absolute;
     top: 0.6rem;
     left: 0.4rem;
@@ -39,7 +43,7 @@
     right: 0.3rem;
   }
 
-  @each $type, $color in $admonition-color-map {
+  @each $type, $color in var.$admonition-color-map {
     &.#{$type} {
       border-left-color: $color;
 
@@ -49,13 +53,13 @@
     }
   }
 
-  @each $type, $color in $admonition-background-color-map {
+  @each $type, $color in var.$admonition-background-color-map {
     &.#{$type} {
       background-color: $color;
 
       .admonition-title {
         border-bottom-color: $color;
-        background-color: opacify($color, 0.15);
+        background-color: color.adjust($color, $alpha: -0.15);
       }
 
       &.open .admonition-title {

--- a/assets/css/_partial/_single/_code.scss
+++ b/assets/css/_partial/_single/_code.scss
@@ -1,10 +1,14 @@
+@use "_mixin/_compatibility" as compat;
+@use "_mixin/_link";
+@use "_variables" as var;
+
 code {
   display: inline-block;
   max-width: 100%;
-  @include overflow-wrap(break-word);
-  @include line-break(anywhere);
-  font-size: $code-font-size;
-  font-family: $code-font-family;
+  @include compat.overflow-wrap(break-word);
+  @include compat.line-break(anywhere);
+  font-size: var.$code-font-size;
+  font-family: var.$code-font-family;
 }
 
 pre {
@@ -20,7 +24,7 @@ pre,
 .highlight table,
 .highlight tr,
 .highlight td {
-  background-color: $code-background-color !important;
+  background-color: var.$code-background-color !important;
 }
 
 code:not(.chroma) {
@@ -44,8 +48,8 @@ a > code:not(.chroma) {
 
 .highlight,
 .gist {
-  font-family: $code-font-family;
-  font-size: $code-font-size;
+  font-family: var.$code-font-family;
+  font-size: var.$code-font-size;
 
   .table-wrapper {
     > table,
@@ -68,9 +72,9 @@ a > code:not(.chroma) {
 
   .gist-meta {
     padding: 0.4rem 0.8rem;
-    background-color: $code-background-color-darken-5;
+    background-color: var.$code-background-color-darken-5;
 
-    @include link(false, false);
+    @include link.link(false, false);
   }
 }
 

--- a/assets/css/_partial/_single/_footer.scss
+++ b/assets/css/_partial/_single/_footer.scss
@@ -1,8 +1,12 @@
+@use "_variables" as var;
+@use "_mixin/_link";
+@use "_mixin/_compatibility" as compat;
+
 .post-footer {
   margin-top: 3rem;
 
   .post-info {
-    border-bottom: 1px solid $global-border-color;
+    border-bottom: 1px solid var.$global-border-color;
     padding: 1rem 0 0.3rem;
 
     .post-info-line {
@@ -11,22 +15,22 @@
 
       .post-info-mod {
         font-size: 0.8em;
-        color: $global-font-secondary-color;
+        color: var.$global-font-secondary-color;
 
-        @include link(false, false);
+        @include link.link(false, false);
       }
 
       .post-info-license {
         font-size: 0.8em;
-        color: $global-font-secondary-color;
+        color: var.$global-font-secondary-color;
 
-        @include link(false, false);
+        @include link.link(false, false);
       }
 
       .post-info-md {
         font-size: 0.8rem;
         width: fit-content;
-        @include link(false, false);
+        @include link.link(false, false);
       }
 
       .post-info-share {
@@ -48,7 +52,7 @@
             vertical-align: text-bottom;
           }
           :hover {
-            color: $global-link-hover-color;
+            color: var.$global-link-hover-color;
           }
         }
 
@@ -107,7 +111,7 @@
     & a.next {
       font-size: 1rem;
       font-weight: 600;
-      @include transition(all 0.3s ease-out);
+      @include compat.transition(all 0.3s ease-out);
     }
 
     & a.prev {
@@ -115,7 +119,7 @@
     }
 
     & a.prev:hover {
-      @include transform(translateX(-4px));
+      @include compat.transform(translateX(-4px));
     }
 
     & a.next {
@@ -123,7 +127,7 @@
     }
 
     & a.next:hover {
-      @include transform(translateX(4px));
+      @include compat.transform(translateX(4px));
     }
   }
 }

--- a/assets/css/_partial/_single/_friend.scss
+++ b/assets/css/_partial/_single/_friend.scss
@@ -1,16 +1,19 @@
+@use "_mixin/_compatibility" as compat;
+@use "_variables" as var;
+
 .friend-link-div {
   height: 92px;
   margin-top: 5px;
   width: 48%;
   display: inline-block;
-  background: $friend-link-background-color;
+  background: var.$friend-link-background-color;
   vertical-align: top;
   -webkit-transition: transform 0.4s ease;
   -moz-transition: transform 0.4s ease;
   -o-transition: transform 0.4s ease;
   transition: transform 0.4s ease;
   &:hover {
-    @include transform(scale(1.01));
+    @include compat.transform(scale(1.01));
   }
   .friend-link-avatar {
     width: 92px;
@@ -25,9 +28,9 @@
   }
   .friend-link-info {
     margin: 18px 18px 18px 92px;
-    color: $friend-link-color;
+    color: var.$friend-link-color;
     &:hover {
-      color: $friend-link-hover-color;
+      color: var.$friend-link-hover-color;
     }
     .friend-name-div {
       text-overflow: ellipsis;
@@ -41,7 +44,7 @@
       text-overflow: ellipsis;
       overflow: hidden;
       white-space: nowrap;
-      color: $global-font-secondary-color;
+      color: var.$global-font-secondary-color;
     }
   }
 }

--- a/assets/css/_partial/_single/_related.scss
+++ b/assets/css/_partial/_single/_related.scss
@@ -1,3 +1,6 @@
+@use "_mixin/_compatibility" as compat;
+@use "_variables" as var;
+
 .related-container {
   display: flex;
   flex-wrap: nowrap;
@@ -12,12 +15,12 @@
     height: 270px;
     min-width: 300px;
     margin-right: 20px;
-    background: $related-background-color;
+    background: var.$related-background-color;
     position: relative;
   }
 
   .related-image {
-    @include transition(transform 0.4s ease);
+    @include compat.transition(transform 0.4s ease);
 
     img {
       width: 100%;
@@ -26,7 +29,7 @@
     }
 
     &:hover {
-      @include transform(scale(1.01));
+      @include compat.transform(scale(1.01));
     }
   }
 
@@ -43,10 +46,10 @@
   }
 
   .related-title a {
-    color: $related-color;
+    color: var.$related-color;
 
     &:hover {
-      color: $related-hover-color;
+      color: var.$related-hover-color;
     }
   }
 }

--- a/assets/css/_partial/_single/_series.scss
+++ b/assets/css/_partial/_single/_series.scss
@@ -1,21 +1,23 @@
+@use "_variables" as var;
+
 .series-nav {
   margin: 0.8rem 0;
   &[kept="true"] {
     display: block;
   }
   .series-title {
-    font-size: $toc-title-font-size;
+    font-size: var.$toc-title-font-size;
     font-weight: bold;
     display: flex;
     justify-content: space-between;
     line-height: 2em;
     padding: 0 0.75rem;
-    background: $code-background-color-darken-6;
+    background: var.$code-background-color-darken-6;
   }
 
   .series-content {
-    font-size: $toc-content-font-size;
-    background-color: $code-background-color;
+    font-size: var.$toc-content-font-size;
+    background-color: var.$code-background-color;
 
     > nav > ul {
       margin: 0;
@@ -31,7 +33,7 @@
         content: "|";
         font-weight: bolder;
         margin-right: 0.5rem;
-        color: $single-link-color;
+        color: var.$single-link-color;
       }
       span.active {
         &:first-child::before {
@@ -39,10 +41,10 @@
           margin-right: 0.5rem;
         }
         font-weight: bolder;
-        color: $single-link-color;
+        color: var.$single-link-color;
 
         &::before {
-          color: $single-link-hover-color;
+          color: var.$single-link-hover-color;
         }
       }
       ul {
@@ -52,7 +54,7 @@
   }
   &.open {
     .toc-title {
-      background: $code-header-color;
+      background: var.$code-header-color;
     }
   }
 }

--- a/assets/css/_partial/_single/_showcase.scss
+++ b/assets/css/_partial/_single/_showcase.scss
@@ -1,9 +1,12 @@
+@use "_mixin/_compatibility" as compat;
+@use "_variables" as var;
+
 .showcase-box {
   width: 48%;
   height: 370px;
   margin: 1% 0% 0% 0%;
   display: inline-block !important;
-  background: $showcase-background-color;
+  background: var.$showcase-background-color;
   position: relative;
 }
 
@@ -21,7 +24,7 @@
 }
 
 .showcase-image {
-  @include transition(transform 0.4s ease);
+  @include compat.transition(transform 0.4s ease);
 
   img {
     width: 96%;
@@ -32,7 +35,7 @@
   }
 
   &:hover {
-    @include transform(scale(1.01));
+    @include compat.transform(scale(1.01));
   }
 }
 
@@ -49,10 +52,10 @@
 }
 
 .showcase-title a {
-  color: $showcase-color;
+  color: var.$showcase-color;
 
   &:hover {
-    color: $showcase-hover-color;
+    color: var.$showcase-hover-color;
   }
 }
 

--- a/assets/css/_partial/_single/_sponsor.scss
+++ b/assets/css/_partial/_single/_sponsor.scss
@@ -1,3 +1,6 @@
+@use "_mixin/_compatibility" as compat;
+@use "_variables" as var;
+
 .sponsor {
   text-align: center;
   padding-top: 50px;
@@ -7,8 +10,8 @@
       width: 6rem;
       height: 6rem;
       margin: 10px;
-      @include border-radius(100%);
-      @include box-shadow(0 0 0 0.3618em rgba(0, 0, 0, 0.05));
+      @include compat.border-radius(100%);
+      @include compat.box-shadow(0 0 0 0.3618em rgba(0, 0, 0, 0.05));
     }
   }
   .sponsor-custom {
@@ -24,14 +27,14 @@
     padding: 5px 10px;
     margin: 15px auto;
     display: inline-block;
-    background-color: $sponsor-button-background-color;
+    background-color: var.$sponsor-button-background-color;
     -webkit-transition: transform 0.4s ease;
     -moz-transition: transform 0.4s ease;
     -o-transition: transform 0.4s ease;
     transition: transform 0.4s ease;
     &:hover {
-      background-color: $sponsor-button-hover-background-color;
-      @include transform(scale(1.05));
+      background-color: var.$sponsor-button-hover-background-color;
+      @include compat.transform(scale(1.05));
     }
     span {
       vertical-align: middle;

--- a/assets/css/_partial/_single/_toc.scss
+++ b/assets/css/_partial/_single/_toc.scss
@@ -1,12 +1,16 @@
+@use "_mixin/_blur";
+@use "_mixin/_compatibility" as compat;
+@use "_variables" as var;
+
 .toc {
   .toc-title {
-    font-size: $toc-title-font-size;
+    font-size: var.$toc-title-font-size;
     font-weight: bold;
     text-transform: uppercase;
   }
 
   .toc-content {
-    font-size: $toc-content-font-size;
+    font-size: var.$toc-content-font-size;
 
     ul {
       text-indent: -0.85rem;
@@ -17,7 +21,7 @@
         content: "|";
         font-weight: bolder;
         margin-right: 0.5rem;
-        color: $single-link-color;
+        color: var.$single-link-color;
       }
 
       ul {
@@ -27,10 +31,10 @@
   }
 
   ruby {
-    background: $code-background-color;
+    background: var.$code-background-color;
 
     rt {
-      color: $global-font-secondary-color;
+      color: var.$global-font-secondary-color;
     }
   }
 }
@@ -39,14 +43,14 @@
   display: block;
   position: absolute;
   padding: 0 0.8rem;
-  border-left: 4px solid $global-border-color;
-  @include overflow-wrap(break-word);
+  border-left: 4px solid var.$global-border-color;
+  @include compat.overflow-wrap(break-word);
   box-sizing: border-box;
   top: 10rem;
   left: 80%;
   width: 20%;
 
-  @include blur;
+  @include blur.blur;
 
   .toc-title {
     margin: 0.8rem 0;
@@ -73,10 +77,10 @@
 
     a.active {
       font-weight: bold;
-      color: $single-link-color;
+      color: var.$single-link-color;
 
       &::before {
-        color: $single-link-hover-color;
+        color: var.$single-link-hover-color;
       }
     }
   }
@@ -95,11 +99,11 @@
     justify-content: space-between;
     line-height: 2em;
     padding: 0 0.75rem;
-    background: $code-background-color-darken-6;
+    background: var.$code-background-color-darken-6;
   }
 
   .toc-content {
-    background-color: $code-background-color;
+    background-color: var.$code-background-color;
 
     > nav > ul {
       margin: 0;
@@ -109,7 +113,7 @@
 
   &.open {
     .toc-title {
-      background: $code-header-color;
+      background: var.$code-header-color;
     }
   }
 }

--- a/assets/css/style.scss
+++ b/assets/css/style.scss
@@ -1,20 +1,20 @@
 @charset "utf-8";
 
-@import "_variables";
-@import "_override";
+@use "_variables";
+@use "_override";
 
-@import "themes/_themes";
+@use "themes/_themes";
 
-@import "_mixin/index";
+@use "_mixin/index" as mix;
 
-@import "_core/base";
+@use "_core/base";
 
-@import "_page/index";
+@use "_page/index";
 
-@import "_partial/header";
-@import "_partial/footer";
-@import "_partial/pagination";
+@use "_partial/header";
+@use "_partial/footer";
+@use "_partial/pagination";
 
-@import "_core/media";
+@use "_core/media";
 
-@import "_custom";
+@use "_custom";

--- a/assets/lib/aplayer/dark.scss
+++ b/assets/lib/aplayer/dark.scss
@@ -81,14 +81,14 @@
   .aplayer-lrc {
     text-shadow: -1px -1px 0 #666;
 
-    &:before {
+    &::before {
       background: -moz-linear-gradient(top, rgba(33,33,33,1) 0%, rgba(33,33,33,0) 100%);
       background: -webkit-linear-gradient(top, rgba(33,33,33,1) 0%,rgba(33,33,33,0) 100%);
       background: linear-gradient(to bottom, rgba(33,33,33,1) 0%,rgba(33,33,33,0) 100%);
       filter: progid:DXImageTransform.Microsoft.gradient( startColorstr='#212121', endColorstr='#00212121',GradientType=0 );
     }
 
-    &:after {
+    &::after {
       background: -moz-linear-gradient(top, rgba(33,33,33,0) 0%, rgba(33,33,33,0.8) 100%);
       background: -webkit-linear-gradient(top, rgba(33,33,33,0) 0%,rgba(33,33,33,0.8) 100%);
       background: linear-gradient(to bottom, rgba(33,33,33,0) 0%,rgba(33,33,33,0.8) 100%);

--- a/assets/lib/valine/Valine.scss
+++ b/assets/lib/valine/Valine.scss
@@ -17,11 +17,11 @@
         .vh, .vquote {
             border: none;
         }
-        .vcontent.expand:after {
+        .vcontent.expand::after {
             color: var.$global-font-color;
             background: $global-background-color;
         }
-        .vcontent.expand:before {
+        .vcontent.expand::before {
             background: linear-gradient(180deg,hsla(0,0%,100%,0),hsla(0,0%,100%,.9));
             .dark & {
                 background: linear-gradient(180deg,hsla(0,0%,100%,0),#292a2de6);

--- a/assets/lib/valine/Valine.scss
+++ b/assets/lib/valine/Valine.scss
@@ -1,25 +1,24 @@
-@import "../../css/_variables";
-
+@use "../../css/_variables";
 
 .v[data-class=v] {
     .vbtn {
-        color: $global-font-color;
+        color: var.$global-font-color;
     }
     .vicon {
-        fill: $global-font-color;
+        fill: var.$global-font-color;
     }
     code, pre {
         background-color: $code-background-color;
     }
     .status-bar, .veditor, .vinput, p, pre code {
-        color: $global-font-color;
+        color: var.$global-font-color;
     }
     .vcards .vcard {
         .vh, .vquote {
             border: none;
         }
         .vcontent.expand:after {
-            color: $global-font-color;
+            color: var.$global-font-color;
             background: $global-background-color;
         }
         .vcontent.expand:before {

--- a/layouts/_partials/plugin/style.html
+++ b/layouts/_partials/plugin/style.html
@@ -15,7 +15,7 @@
             {{- $resource = $resource | resources.ExecuteAsTemplate . $.Context -}}
         {{- end -}}
         {{- with .ToCSS -}}
-            {{- $options := . | merge (dict "outputStyle" "compressed") -}}
+            {{- $options := . | merge (dict "outputStyle" "compressed" "transpiler" "dartsass") -}}
             {{- $resource = $resource | toCSS $options -}}
         {{- end -}}
         {{- if .Minify -}}


### PR DESCRIPTION
Currently, for creating css from the theme's sass files, Hugo's [default transpiler](https://gohugo.io/functions/css/sass/#transpiler) `libsass` is used. However, `libsass` is [deprecated](https://sass-lang.com/blog/libsass-is-deprecated/) in favor of `dartsass`.

This PR brings in the use of recommended `dartsass` transpiler when processing theme's .scss file. After switching to `dartsass`, tons of warnings were emitted initially when transpiling the .scss files (mostly on the use of deprecated `@import` statement and due to the use of global variables). Almost all of these warnings have been fixed by changing the offending .scss files. There are only three warnings remaining which I couldn't fix easily.

This PR also brings in uniform syntax for pseudo elements `::after` and `::before` in all .scss files.

I hope you like this PR.