### PR TITLE
feat: add featuredImageCaption to front matter

### DIFF
--- a/exampleSite/content/posts/theme-documentation-content/index.en.md
+++ b/exampleSite/content/posts/theme-documentation-content/index.en.md
@@ -191,6 +191,7 @@ related:
 * **series_weight**: {{< version 0.2.13 >}} define the [position](https://gohugo.io/content-management/taxonomies/#order-taxonomies) of the post in the series.
 * **seriesNavigation**: {{< version 0.2.13 >}} whether to enable series navigation.
 * **featuredImage**: the featured image for the content.
+* **featuredImageCaption**: {{< version 0.4.3 >}} the caption for the featured image.
 * **featuredImagePreview**: the featured image for the content preview in the home page.
 
 * **hiddenFromHomePage**: if `true`, the content will not be shown in the home page.

--- a/exampleSite/content/posts/theme-documentation-content/index.zh-cn.md
+++ b/exampleSite/content/posts/theme-documentation-content/index.zh-cn.md
@@ -190,6 +190,7 @@ related:
 * **series_weight**: {{< version 0.2.13 >}} 自定义文章在系列中的[位置](https://gohugo.io/content-management/taxonomies/#order-taxonomies).
 * **seriesNavigation**: {{< version 0.2.13 >}} 是否使用系列导航.
 * **featuredImage**: 文章的特色图片.
+* **featuredImageCaption**: {{< version 0.4.3 >}} 特写图片的说明文字.
 * **featuredImagePreview**: 用在主页预览的文章特色图片.
 
 * **hiddenFromHomePage**: 如果设为 `true`, 这篇文章将不会显示在主页上.

--- a/layouts/posts/single.html
+++ b/layouts/posts/single.html
@@ -170,7 +170,16 @@
                     (dict "Process" "resize 1200x webp q75" "descriptor" "1200w")
                     (dict "Process" "resize 1600x webp q75" "descriptor" "1600w") 
                 -}}
+                {{- if page.Params.featuredImageCaption -}}
+                    <figure>
+                {{- end -}}
                 {{- dict "Src" . "Title" $.Description "Resources" $.Resources "Loading" "eager" "OptimConfig" $optim | partial "plugin/image.html" -}}
+                {{- if page.Params.featuredImageCaption -}}
+                {{- with page.Params.featuredImageCaption | default "" -}}
+                    <figcaption>{{ . }}</figcaption>
+                {{- end -}}
+                    </figure>
+                {{- end -}}
             </div>
         {{- end -}}      
         {{- /* Series list */ -}}


### PR DESCRIPTION
Introduce a new key 'featuredImageCaption' that allows to add a caption to the featuredImage of a post.

This implements #1522.