### PR TITLE
feat: Add Naver to site verification

### DIFF
--- a/exampleSite/config/_default/params.toml
+++ b/exampleSite/config/_default/params.toml
@@ -549,8 +549,8 @@ bundle = false
   # 打字结束之后光标的持续时间 (单位是毫秒, "-1" 代表无限大)
   duration = -1
 
-# Site verification code for Google/Bing/Yandex/Pinterest/Baidu
-# 网站验证代码，用于 Google/Bing/Yandex/Pinterest/Baidu
+# Site verification code for Google/Bing/Yandex/Pinterest/Baidu/Naver
+# 网站验证代码，用于 Google/Bing/Yandex/Pinterest/Baidu/Naver
 [verification]
   google = "MQ8DNu27ayX6B_4ObiEDK09vGr1fdy7kOAnbd09hJk4"
   bing = ""
@@ -559,6 +559,7 @@ bundle = false
   baidu = ""
   so = ""
   sogou = ""
+  naver = ""
 
 # Site SEO config
 # 网站 SEO 配置

--- a/layouts/_partials/head/seo.html
+++ b/layouts/_partials/head/seo.html
@@ -19,6 +19,9 @@
 {{- with .Site.Params.verification.so -}}
     <meta name="360-site-verification" content="{{ . }}" />
 {{- end -}}
+{{- with .Site.Params.verification.naver -}}
+    <meta name="naver-site-verification" content="{{ . }}" />
+{{- end -}}
 
 {{- define "blogPosting" -}}
 {{- $params := .Scratch.Get "params" -}}


### PR DESCRIPTION
> [NAVER](https://www.naver.com/) is South Korea’s leading online platform, offering a wide range of services including search, news, email, blogs, and shopping.

### Description
This pull request adds a Naver site verification meta tag to the <head> section of the website.

The verification code is required for ownership validation in Naver Search Console, enabling search result analytics and indexing management.

### Changes
- Added meta name="naver-site-verification" with the assigned verification token
- Ensured consistent placement with existing Google and Bing verification tags

### Purpose
To verify domain ownership with Naver Webmaster Tools, allowing proper indexing and analytics tracking for Korean search visibility.