### PR TITLE
fix: add definition list styling to single page content

### DIFF
--- a/assets/css/_page/_single.scss
+++ b/assets/css/_page/_single.scss
@@ -247,6 +247,22 @@
       margin: 1rem 0;
     }
 
+    dl {
+      margin: 1rem 0;
+    }
+
+    dt {
+      font-weight: 600;
+    }
+
+    dd {
+      margin: 0.25rem 0 0 1.5rem;
+    }
+
+    dd + dt {
+      margin-top: 0.75rem;
+    }
+
     .footnotes {
       color: $global-font-secondary-color;
 

--- a/exampleSite/content/posts/tests/markdown-tests/index.en.md
+++ b/exampleSite/content/posts/tests/markdown-tests/index.en.md
@@ -168,6 +168,17 @@ This is a footnote with "label"[^label]
 [^1]: This is a digital footnote
 [^label]: This is a footnote with "label"
 
+## Definition Lists
+
+OAuth 2.0
+: An authorization framework for delegated access.
+
+PKCE
+: Proof Key for Code Exchange.
+
+Mermaid
+: A text-based diagramming tool.
+
 ## Images
 
 ![Minion](https://octodex.github.com/images/minion.png)


### PR DESCRIPTION
## Summary
- Add `dl`, `dt`, `dd` styles to `.content` in `_single.scss` to fix definition lists rendering as plain paragraphs
- Tailwind's Preflight reset zeroes out `dl`/`dd` margins with no replacement styles, so definition lists lose all visual structure

Fixes #1590

## Changes
- `dl`: `margin: 1rem 0` (vertical spacing around the list)
- `dt`: `font-weight: 600` (bold terms)
- `dd`: `margin: 0.25rem 0 0 1.5rem` (indented definitions)
- `dd + dt`: `margin-top: 0.75rem` (spacing between items)

## Test plan
- [x] Create a page with Goldmark definition list markup and verify terms are bold, definitions are indented, and items have proper spacing
- [x] `npm run build` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)