### PR TITLE
fix: skip style attribute on table cells with no alignment

### DIFF
--- a/layouts/_markup/render-table.html
+++ b/layouts/_markup/render-table.html
@@ -13,7 +13,7 @@
       {{- range .THead }}
         <tr>
           {{- range . }}
-            <th {{ printf "style=%q" (printf "text-align: %s" .Alignment) | safeHTMLAttr }}>
+            <th{{ with .Alignment }} style="text-align: {{ . }}"{{ end }}>
               {{- .Text -}}
             </th>
           {{- end }}
@@ -24,7 +24,7 @@
       {{- range .TBody }}
         <tr>
           {{- range . }}
-            <td {{ printf "style=%q" (printf "text-align: %s" .Alignment) | safeHTMLAttr }}>
+            <td{{ with .Alignment }} style="text-align: {{ . }}"{{ end }}>
               {{- .Text -}}
             </td>
           {{- end }}

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "pagefind": "npx pagefind --site ./exampleSite/public",
     "build:tailwind": "npx @tailwindcss/cli -i ./assets/css/tailwind.css -o ./assets/css/main.css",
     "format": "npx prettier . --write",
-    "validate": "npm run build && docker run --rm -v \"$(pwd)/exampleSite/public\":/check ghcr.io/validator/validator:latest vnu --skip-non-html --format json /check/ 2>&1"
+    "validate": "npm run build:preview && docker run --rm -v \"$(pwd)/exampleSite/public\":/check ghcr.io/validator/validator:latest vnu --skip-non-html --format json /check/ 2>&1"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Summary

- Fixes W3C CSS parse errors caused by \`style="text-align: "\` (empty value) being emitted on table cells with no alignment marker in the source Markdown
- Uses \`{{ with .Alignment }}\` to only render the \`style\` attribute when an alignment value is actually present
- Eliminates all CSS \`"text-align": Parse Error\` W3C validation errors (part of #1498)

> [!NOTE]
> The \`validate\` script must be run as \`npm run validate\` (which uses \`build:preview\`) to include draft pages like \`katex-tests\` in the validation. Running against the regular build would miss those pages and show false negatives.

## Test plan

- [x] Run \`npm run validate\` and confirm zero CSS \`"text-align"\` parse errors
- [x] Visually confirm tables with aligned and unaligned columns render correctly

🤖 Generated with [Claude Code](https://claude.ai/claude-code)