### PR TITLE
fix: replace button wrappers with div for language and theme selectors

### DIFF
--- a/layouts/_partials/header.html
+++ b/layouts/_partials/header.html
@@ -43,7 +43,7 @@
                 <span class="menu-item delimiter"></span>
                 {{- end -}}
                 {{- if hugo.IsMultilingual -}}
-                <button class="menu-item language" {{ printf "aria-label=%q" (T "selectLanguage") | safeHTMLAttr }}>
+                <div class="menu-item language tw:inline-block">
                     {{- .Language.Label -}}
                     {{ partial "plugin/fontawesome.html" (dict "Style" "solid" "Icon" "chevron-right") }}
                     <select class="language-select" {{ printf "aria-label=%q" (T "selectLanguage") | safeHTMLAttr }} id="language-select-desktop"
@@ -64,7 +64,7 @@
                         {{- end -}}
                         {{- end -}}
                     </select>
-                </button>
+                </div>
                 {{- end -}}
                 {{- if .Site.Params.search.enable -}}
                 <span class="menu-item search" id="search-desktop">
@@ -83,14 +83,14 @@
                 </span>
                 {{- end -}}
                 {{- if eq .Site.Params.header.themeChangeMode "select" -}}
-                <button class="menu-item theme-select" {{ printf "aria-label=%q" (T "switchTheme") | safeHTMLAttr }}>
+                <div class="menu-item theme-select tw:inline-block">
                     {{ partial "plugin/fontawesome.html" (dict "Style" "solid" "Icon" "adjust") }}
                     <select class="color-theme-select" id="theme-select-desktop" {{ printf "aria-label=%q" (T "switchTheme") | safeHTMLAttr }}>
                         <option value="light">{{ T "Light" }}</option>
                         <option value="dark">{{ T "Dark" }}</option>
                         <option value="auto">{{ T "Auto" }}</option>
                     </select>
-                </button>
+                </div>
                 {{- else -}}
                 <button class="menu-item theme-switch" {{ printf "aria-label=%q" (T "switchTheme") | safeHTMLAttr }}>
                     {{ partial "plugin/fontawesome.html" (dict "Style" "solid" "Icon" "adjust") }}
@@ -170,21 +170,21 @@
             </a>
             {{- end -}}
             {{- if eq .Site.Params.header.themeChangeMode "select" -}}
-            <button class="menu-item theme-select tw:w-full" {{ printf "aria-label=%q" (T "switchTheme") | safeHTMLAttr }}>
+            <div class="menu-item theme-select tw:w-full">
                 {{ partial "plugin/fontawesome.html" (dict "Style" "solid" "Icon" "adjust") }}
                 <select class="color-theme-select" id="theme-select-mobile" {{ printf "aria-label=%q" (T "switchTheme") | safeHTMLAttr }}>
                     <option value="light">{{ T "Light" }}</option>
                     <option value="dark">{{ T "Dark" }}</option>
                     <option value="auto">{{ T "Auto" }}</option>
                 </select>
-            </button>
+            </div>
             {{- else -}}
             <button class="menu-item theme-switch tw:w-full" {{ printf "aria-label=%q" (T "switchTheme") | safeHTMLAttr }}>
                 {{ partial "plugin/fontawesome.html" (dict "Style" "solid" "Icon" "adjust") }}
             </button>
             {{- end -}}
             {{- if hugo.IsMultilingual -}}
-            <button class="menu-item tw:w-full" title="{{ T " selectLanguage" }}">
+            <div class="menu-item tw:w-full" title="{{ T " selectLanguage" }}">
                 {{- .Language.Label -}}
                 {{ partial "plugin/fontawesome.html" (dict "Style" "solid" "Icon" "chevron-right") }}
                 <select class="language-select" title="{{ T " selectLanguage" }}" onchange="location = this.value;">
@@ -204,7 +204,7 @@
                     {{- end -}}
                     {{- end -}}
                 </select>
-            </button>
+            </div>
             {{- end -}}
         </div>
     </div>


### PR DESCRIPTION
## Summary

- Fixes W3C validation errors caused by `<select>` (and cascading icon content) being nested inside `<button>`, which is invalid HTML
- Replaces all 4 `<button>` wrappers in the header (desktop language, desktop theme, mobile theme, mobile language) with `<div>`
- Desktop wrappers get `tw:inline-block` to preserve horizontal menu layout — `<button>` is `inline-block` by default, `<div>` is `block`
- Mobile wrappers need no display change since SCSS already sets `display: block` for `.menu .menu-item`
- `aria-label` removed from the wrapper divs since they are non-interactive; the `<select>` elements inside already carry their own `aria-label`
- All CSS styling and JS behavior is preserved — the invisible select overlay trick works identically with a `<div>` container

Fixes 396 W3C validation errors (part of #1498).

## Test plan

- [ ] Run `npm run validate` and confirm the `<select> must not appear as a descendant of <button>` errors are gone
- [ ] Visually confirm the desktop header language and theme selectors still appear and function correctly
- [ ] Visually confirm the mobile menu language and theme selectors still appear and function correctly

🤖 Generated with [Claude Code](https://claude.ai/claude-code)