### PR TITLE
fix: quote href attribute value in post footer links

### DIFF
--- a/exampleSite/config/_default/params.toml
+++ b/exampleSite/config/_default/params.toml
@@ -168,9 +168,9 @@ bundle = false
   # https://bitbucket.org/user/repo/src/main/{path}?mode=edit
   # configure the link to report issue for the post
   # 配置提交错误的链接
-  linkToReport = "https://github.com/HEIGE-PCloud/DoIt/issues/new?title=[bug]%20{title}&body=|Field|Value|%0A|-|-|%0A|Title|{title}|%0A|Url|{url}|%0A|Filename|https://github.com/HEIGE-PCloud/DoIt/blob/main/exampleSite/content/{path}|"
-  # https://github.com/user/repo/issues/new?title=[bug]%20{title}&body=|Field|Value|%0A|-|-|%0A|Title|{title}|%0A|Url|{url}|%0A|Filename|https://github.com/user/repo/blob/main/{path}|"
-  # https://gitlab.com/user/repo/-/issues/new?issue[title]=[bug]%20{title}&issue[description]=|Field|Value|%0A|-|-|%0A|Title|{title}|%0A|Url|{url}|%0A|Filename|https://gitlab.com/user/repo/-/edit/main/{path}|
+  linkToReport = "https://github.com/HEIGE-PCloud/DoIt/issues/new?title=%5Bbug%5D%20{title}&body=|Field|Value|%0A|-|-|%0A|Title|{title}|%0A|Url|{url}|%0A|Filename|https://github.com/HEIGE-PCloud/DoIt/blob/main/exampleSite/content/{path}|"
+  # https://github.com/user/repo/issues/new?title=%5Bbug%5D%20{title}&body=|Field|Value|%0A|-|-|%0A|Title|{title}|%0A|Url|{url}|%0A|Filename|https://github.com/user/repo/blob/main/{path}|"
+  # https://gitlab.com/user/repo/-/issues/new?issue%5Btitle%5D=%5Bbug%5D%20{title}&issue%5Bdescription%5D=|Field|Value|%0A|-|-|%0A|Title|{title}|%0A|Url|{url}|%0A|Filename|https://gitlab.com/user/repo/-/edit/main/{path}|
   # whether to show the full text content in RSS
   # 是否在 RSS 中显示全文内容
   rssFullText = false

--- a/layouts/_partials/single/footer.html
+++ b/layouts/_partials/single/footer.html
@@ -57,7 +57,7 @@
                         {{- if gt $index 0 -}}
                             |&nbsp;
                         {{- end -}}
-                        <a class="{{ $value.class }}" {{ printf "href=%v" $value.link | safeHTMLAttr }} target="_blank" rel="noopener noreferrer">
+                        <a class="{{ $value.class }}" {{ printf "href=%q" $value.link | safeHTMLAttr }} target="_blank" rel="noopener noreferrer">
                             {{- T $value.text -}}
                         </a>
                     </span>


### PR DESCRIPTION
## Summary

- Footer links (link-to-markdown, link-to-source, link-to-edit, link-to-report) used `printf "href=%v"` which produced an unquoted attribute value — URLs containing `=` in query strings are invalid in unquoted HTML attributes
- Changing `%v` to `%q` wraps the URL in double-quotes, producing a valid quoted attribute
- Also percent-encodes `[` → `%5B` and `]` → `%5D` in the `linktoreport` example URL template in the config — square brackets are not valid in URL query strings per RFC 3986 (browsers decode them identically, so behaviour is unchanged)

Fixes 126 W3C validation errors (part of #1498).

## Test plan

- [ ] Run `npm run validate` and confirm the `"=" in an unquoted attribute value` and `Illegal character "[" in query` errors are gone
- [ ] Confirm footer links (view source, edit, report) still render and open correctly, and that the GitHub issue title still shows `[bug]`

🤖 Generated with [Claude Code](https://claude.ai/claude-code)