### PR TITLE
fix: replace div and p with span inside codeblock button

### DIFF
--- a/layouts/_markup/render-codeblock.html
+++ b/layouts/_markup/render-codeblock.html
@@ -33,8 +33,8 @@
         tw:flex-row
         tw:flex-1"
       aria-hidden="true">
-          <div class="tw:group-[.is-open]:rotate-90 tw:transition-[transform] tw:duration-500 tw:ease-in-out tw:print:hidden! tw:w-min tw:h-min tw:my-1 tw:mx-1">{{- partial "plugin/fontawesome.html" (dict "Style" "solid" "Icon" "chevron-right") -}}</div>
-          <p class="tw:select-none tw:my-1!">{{ $title }}</p>
+          <span class="tw:group-[.is-open]:rotate-90 tw:transition-[transform] tw:duration-500 tw:ease-in-out tw:print:hidden! tw:w-min tw:h-min tw:my-1 tw:mx-1">{{- partial "plugin/fontawesome.html" (dict "Style" "solid" "Icon" "chevron-right") -}}</span>
+          <span class="tw:select-none tw:my-1! tw:block">{{ $title }}</span>
       </button>
 
    <div class="tw:flex">


### PR DESCRIPTION
## Summary

The code block header uses a `<button>` to toggle collapse/expand state. It contained a `<div>` (chevron icon wrapper) and a `<p>` (title text) as direct children — block elements are not permitted inside `<button>` per the HTML spec.

Replace both with `<span>`:
- Icon wrapper `<div>` → `<span>` (no display change needed, already sized with `tw:w-min`/`tw:h-min`)
- Title `<p>` → `<span class="tw:block">` (`tw:block` replicates the block display of the replaced `<p>`)

Fixes 634 W3C validation errors (part of #1498).

## Test plan

- [x] Run `npm run validate` and confirm the `Element "div"/"p" not allowed as child of element "button"` errors are gone
- [x] Visually confirm code blocks still render correctly with title, chevron, and collapse/expand behaviour

🤖 Generated with [Claude Code](https://claude.ai/claude-code)