### PR TITLE
fix: replace article with div for archive list items

### DIFF
--- a/layouts/_partials/recentlyUpdated.html
+++ b/layouts/_partials/recentlyUpdated.html
@@ -12,14 +12,14 @@
                         <h3 class="group-title">{{- T "recentlyUpdated" -}}</h3>
                         {{- $hasTitle = true -}}
                     {{- end -}}
-                    <article class="archive-item">
+                    <div class="archive-item">
                         <a href="{{ .RelPermalink }}" class="archive-item-link">
                             {{- .Title -}}
                         </a>
                         <span class="archive-item-date">
                             {{- $.Site.Params.section.recentlyUpdated.dateFormat | default $.Site.Params.section.dateFormat | default "01-02" | .Lastmod.Format -}}
                         </span>
-                    </article>
+                    </div>
                 {{- end -}}
             {{- end -}}
         {{- end -}}

--- a/layouts/section.html
+++ b/layouts/section.html
@@ -21,14 +21,14 @@
             {{- range .Paginator.PageGroups -}}
                 <h3 class="group-title">{{ .Key }}</h3>
                 {{- range .Pages -}}
-                    <article class="archive-item">
+                    <div class="archive-item">
                         <a href="{{ .RelPermalink }}" class="archive-item-link">
                             {{- .Title -}}
                         </a>
                         <span class="archive-item-date">
                             {{- $.Site.Params.section.dateFormat | default "01-02" | .Date.Format -}}
                         </span>
-                    </article>
+                    </div>
                 {{- end -}}
             {{- end -}}
             {{- partial "paginator.html" . -}}

--- a/layouts/taxonomy.html
+++ b/layouts/taxonomy.html
@@ -28,11 +28,11 @@
                                 </a>
                             </h3>
                             {{- range first 5 $pages -}}
-                                <article class="archive-item">
+                                <div class="archive-item">
                                     <a href="{{ .RelPermalink }}" class="archive-item-link">
                                         {{- .Title -}}
                                     </a>
-                                </article>
+                                </div>
                             {{- end -}}
                             {{- if gt (len $pages) 5 -}}
                                 <span class="more-post">
@@ -61,11 +61,11 @@
                                 </a>
                             </h3>
                             {{- range first 5 $pages -}}
-                                <article class="archive-item">
+                                <div class="archive-item">
                                     <a href="{{ .RelPermalink }}" class="archive-item-link">
                                         {{- .Title -}}
                                     </a>
-                                </article>
+                                </div>
                             {{- end -}}
                             {{- if gt (len $pages) 5 -}}
                                 <span class="more-post">
@@ -77,7 +77,7 @@
                     {{- end -}}
                 {{- end -}}
             </div>
-            
+
         {{- /* Author Page */ -}}
         {{- else if eq $taxonomies "authors" -}}
             {{- $terms := .Data.Terms.Alphabetical -}}
@@ -94,11 +94,11 @@
                                 </a>
                             </h3>
                             {{- range first 5 $pages -}}
-                                <article class="archive-item">
+                                <div class="archive-item">
                                     <a href="{{ .RelPermalink }}" class="archive-item-link">
                                         {{- .Title -}}
                                     </a>
-                                </article>
+                                </div>
                             {{- end -}}
                             {{- if gt (len $pages) 5 -}}
                                 <span class="more-post">

--- a/layouts/term.html
+++ b/layouts/term.html
@@ -59,27 +59,27 @@
             {{- $taxonomy := .Data.Singular -}}
             {{- if eq $taxonomy "series" -}}
                 {{- range .Paginator.Pages -}}
-                    <article class="archive-item">
+                    <div class="archive-item">
                         <a href="{{ .RelPermalink }}" class="archive-item-link">
                             {{- .Title -}}
                         </a>
                         <span class="archive-item-date">
                             {{- $.Site.Params.dateFormat | default "2006-01-02" | .Date.Format -}}
                         </span>
-                    </article>
+                    </div>
                 {{- end -}}
             {{- else -}}
                 {{- range .Paginator.PageGroups -}}
                     <h3 class="group-title">{{ .Key }}</h3>
                     {{- range .Pages -}}
-                        <article class="archive-item">
+                        <div class="archive-item">
                             <a href="{{ .RelPermalink }}" class="archive-item-link">
                                 {{- .Title -}}
                             </a>
                             <span class="archive-item-date">
                                 {{- $.Site.Params.list.dateFormat | default "01-02" | .Date.Format -}}
                             </span>
-                        </article>
+                        </div>
                     {{- end -}}
                 {{- end -}}
             {{- end -}}


### PR DESCRIPTION
## Summary

- Archive list items in `section.html`, `taxonomy.html`, `term.html`, and `recentlyUpdated.html` used `<article>` elements containing only a link and date span — no heading element
- The W3C validator warns that `<article>` elements must have a heading (h2-h6)
- These items are not standalone self-contained articles in the HTML5 semantic sense, so `<div class="archive-item">` is the correct element
- Eliminates all 218 "Article lacks heading" warnings

## Test plan

- [ ] Run `npm run validate` — "Article lacks heading" warnings should be gone
- [ ] Check archive pages (posts section, categories, tags, series) still render correctly

Closes part of #1498

🤖 Generated with [Claude Code](https://claude.com/claude-code)