### PR TITLE
fix: remove obsolete iframe attributes from bilibili shortcode

### DIFF
--- a/layouts/_shortcodes/bilibili.html
+++ b/layouts/_shortcodes/bilibili.html
@@ -75,5 +75,5 @@
 {{- $url := printf "//player.bilibili.com/player.html?bvid=%s&page=%v%s%s%s%s%s%s%s%s%s" $bvid $page $autoplayPara $danmakuPara $mutedPara $tPara $hasMuteButtonPara $hideCoverInfoPara $hideDanmakuButtonPara $noFullScreenButtonPara $fjwPara -}}
 
 <div class="bilibili">
-    <iframe src="{{ $url }}" scrolling="no" border="0" frameborder="no" framespacing="0" allowfullscreen="true"></iframe>
+    <iframe src="{{ $url }}" allowfullscreen></iframe>
 </div>


### PR DESCRIPTION
## Summary

- Remove obsolete `scrolling`, `border`, `frameborder`, `framespacing` attributes from the bilibili `<iframe>` (10 errors + 30 warnings)
- Change `allowfullscreen="true"` → boolean `allowfullscreen` (10 errors)
- The existing `.bilibili iframe` CSS already handles sizing/appearance, so no visual change

## Test plan

- [ ] Run `npm run validate` — bilibili iframe errors/warnings should be gone
- [ ] Check bilibili embeds still render correctly on the extended-shortcodes demo page

Closes part of #1498

🤖 Generated with [Claude Code](https://claude.com/claude-code)