### PR TITLE
fix: replace section with div in single post footer

### DIFF
--- a/layouts/_partials/single/footer.html
+++ b/layouts/_partials/single/footer.html
@@ -71,7 +71,7 @@
     </div>
 
     <div class="post-info-more">
-        <section class="post-tags">
+        <div class="post-tags">
             {{- with .Params.tags -}}
                 {{ partial "plugin/fontawesome.html" (dict "Style" "solid" "Icon" "tags") }}&nbsp;
                 {{- range $index, $value := . -}}
@@ -80,10 +80,10 @@
                     <a href="{{ $tag.RelPermalink }}">{{ $tag.Title }}</a>
                 {{- end -}}
             {{- end -}}
-        </section>
-        <section class="tw:print:hidden!">
+        </div>
+        <div class="tw:print:hidden!">
             <span><button class="tw:text-fgColor-link-muted tw:hover:text-fgColor-link-muted-hover" onclick="window.history.back();">{{ T "back" }}</button></span>&nbsp;|&nbsp;<span><a href="{{ .Site.Home.RelPermalink }}">{{ T "home" }}</a></span>
-        </section>
+        </div>
     </div>
 
     <div class="post-nav tw:print:hidden">


### PR DESCRIPTION
## Summary

- Two `<section>` elements in `_partials/single/footer.html` (post tags and back/home nav) had no heading, generating 84 "Section lacks heading" W3C warnings
- These are presentational groupings, not semantic sections — changed to `<div>`
- CSS targets class names (`.post-tags`), so no visual change

## Test plan

- [ ] Run `npm run validate` — "Section lacks heading" warnings should be gone
- [ ] Check post footer (tags, back/home links) still renders correctly

Closes part of #1498

🤖 Generated with [Claude Code](https://claude.com/claude-code)