### PR TITLE
fix: don't emit defer on type=module scripts

### DIFF
--- a/layouts/_partials/plugin/script.html
+++ b/layouts/_partials/plugin/script.html
@@ -30,7 +30,7 @@
     src="{{ $src }}"
     {{ if .Crossorigin }}crossorigin="anonymous"{{ end }}{{ with $integrity }}
       integrity="{{ . }}"
-    {{ end }}{{ if .Async }}async{{ end }}{{ if .Defer }}
+    {{ end }}{{ if .Async }}async{{ end }}{{ if and .Defer (not .Module) }}
       defer
     {{ end }}{{ if .Module }}type="module"{{ end }}{{ with .Attr }}{{ . | safeHTMLAttr }}{{ end }}
   ></script>


### PR DESCRIPTION
## Summary

ES modules (`type="module"`) are deferred by default — the HTML spec prohibits using the `defer` attribute alongside `type="module"`. The `plugin/script.html` partial was emitting both when callers set `Defer: true` and `Module: true`.

Fix: suppress `defer` in the partial when `Module` is true.

Fixes 3 W3C validation errors.

## Test plan

- [ ] Run `npm run validate` — `script type=module defer` errors should be gone
- [ ] Verify module scripts (e.g. tab container) still load correctly

Closes part of #1498

🤖 Generated with [Claude Code](https://claude.com/claude-code)