### PR TITLE
fix: replace invalid home posts attribute with data-posts

### DIFF
--- a/assets/css/_page/_home.scss
+++ b/assets/css/_page/_home.scss
@@ -62,7 +62,7 @@
   }
 }
 
-.home[posts] {
+.home[data-posts] {
   .home-profile {
     @include transform(translateY(0));
     padding-top: 2rem;

--- a/layouts/home.html
+++ b/layouts/home.html
@@ -12,7 +12,7 @@
     {{- $profile := .Site.Params.home.profile -}}
     {{- $posts := .Site.Params.home.posts -}}
 
-    <div class="page home"{{ if ne $posts.enable false | or .Content }} posts{{ end }}>
+    <div class="page home"{{ if ne $posts.enable false | or .Content }} data-posts{{ end }}>
         {{- /* Profile */ -}}
         {{- if ne $profile.enable false -}}
             {{- partial "home/profile.html" . -}}


### PR DESCRIPTION
## Summary
- replace invalid boolean-like posts attribute on home page container with valid data-posts
- update SCSS selector from .home[posts] to .home[data-posts]

## Validation
- reran npm run validate
- confirmed Attribute “posts” not allowed on element “div” no longer appears