### PR TITLE
fix: alert blockquote default title not displayed with hardWraps enabled

### DIFF
--- a/layouts/_markup/render-blockquote-alert.html
+++ b/layouts/_markup/render-blockquote-alert.html
@@ -1,3 +1,5 @@
-{{- partial "plugin/admonitionPre.html" (dict "Type" .AlertType "Title" (.AlertTitle | default (strings.FirstUpper .AlertType)) "Open" (not (eq .AlertSign "-"))) -}}
+{{- $alertTitle := .AlertTitle | plainify | strings.TrimSpace -}}
+{{- $title := cond (eq $alertTitle "") (strings.FirstUpper .AlertType) $alertTitle -}}
+{{- partial "plugin/admonitionPre.html" (dict "Type" .AlertType "Title" $title "Open" (not (eq .AlertSign "-"))) -}}
 {{- .Text -}}
 {{- partial "plugin/admonitionPost.html" -}}


### PR DESCRIPTION
As mentioned in #1626 , when `hardWraps` is enabled, Hugo's Goldmark parser converts newlines in the alert title to `<br>` tags. The template's `default` function treats `<br>` as a non-empty value, preventing the fallback to the default title.

**Fix:** Use `plainify` to strip HTML tags, then explicitly check for empty string with `cond` before falling back to the type-based title.
