### PR TITLE
Restore fingerprinting for built assets

### DIFF
--- a/layouts/_partials/assets.html
+++ b/layouts/_partials/assets.html
@@ -49,8 +49,7 @@
     {{- $options = dict "targetPath" "js/twemoji.min.js" | merge $options -}}
     {{- $options = dict "minify" true | merge $options -}}
     {{- $js := resources.Get "js/lib/twemoji.js" | js.Build $options -}}
-    {{- $_ := $js.RelPermalink -}}
-    {{- dict "Link" $js.RelPermalink "Fingerprint" $fingerprint "Defer" true | dict "Scratch" .Scratch "Data" | partial "scratch/script.html" -}}
+    {{- dict "Resource" $js "Fingerprint" $fingerprint "Defer" true | dict "Scratch" .Scratch "Data" | partial "scratch/script.html" -}}
 {{- end -}}
 
 {{- /* lightgallery.js */ -}}
@@ -100,8 +99,7 @@
         {{- $options = dict "targetPath" "js/mathjax.min.js" | merge $options -}}
         {{- $options = dict "minify" true | merge $options -}}
         {{- $js := resources.Get "js/lib/mathjax.js" | js.Build $options -}}
-        {{- $_ := $js.RelPermalink -}}
-        {{- dict "Link" $js.RelPermalink "Fingerprint" $fingerprint | dict "Scratch" .Scratch "Data" | partial "scratch/script.html" -}}
+        {{- dict "Resource" $js "Fingerprint" $fingerprint | dict "Scratch" .Scratch "Data" | partial "scratch/script.html" -}}
 
     {{- else -}}
 
@@ -127,8 +125,7 @@
         {{- $options = dict "minify" true | merge $options -}}
         {{- $options = dict "shims" $shims | merge $options -}}
         {{- $js := resources.Get "js/lib/katex.js" | js.Build $options -}}
-        {{- $_ := $js.RelPermalink -}}
-        {{- dict "Link" $js.RelPermalink "Fingerprint" $fingerprint "Defer" true | dict "Scratch" .Scratch "Data" | partial "scratch/script.html" -}}
+        {{- dict "Resource" $js "Fingerprint" $fingerprint "Defer" true | dict "Scratch" .Scratch "Data" | partial "scratch/script.html" -}}
 
     {{- end -}}
 
@@ -168,8 +165,7 @@
     {{- $options = dict "shims" $shims | merge $options -}}
 
     {{- $js := resources.Get "js/lib/echarts.js" | js.Build $options -}}
-    {{- $_ := $js.RelPermalink -}}
-    {{- dict "Link" $js.RelPermalink "Fingerprint" $fingerprint "Defer" true | dict "Scratch" .Scratch "Data" | partial "scratch/script.html" -}}
+    {{- dict "Resource" $js "Fingerprint" $fingerprint "Defer" true | dict "Scratch" .Scratch "Data" | partial "scratch/script.html" -}}
 {{- end -}}
 
 {{- /* Mapbox GL */ -}}
@@ -189,8 +185,7 @@
     {{- dict "Source" $source "Fingerprint" $fingerprint "Defer" true | dict "Scratch" .Scratch "Data" | partial "scratch/script.html" -}}
     {{- $options := dict "targetPath" "js/plantuml.min.js" "minify" true "sourceMap" "inline" -}}
     {{- $js := resources.Get "js/lib/plantuml.js" | js.Build $options -}}
-    {{- $_ := $js.RelPermalink -}}
-    {{- dict "Link" $js.RelPermalink "Fingerprint" $fingerprint "Defer" true | dict "Scratch" .Scratch "Data" | partial "scratch/script.html" -}}
+    {{- dict "Resource" $js "Fingerprint" $fingerprint "Defer" true | dict "Scratch" .Scratch "Data" | partial "scratch/script.html" -}}
 {{- end -}}
 
 {{- /* WaveDrom */ -}}
@@ -202,8 +197,7 @@
     {{- dict "Source" $source "Fingerprint" $fingerprint "Defer" true | dict "Scratch" .Scratch "Data" | partial "scratch/script.html" -}}
     {{- $options := dict "targetPath" "js/wavedrom.min.js" "minify" true "sourceMap" "inline" -}}
     {{- $js := resources.Get "js/lib/wavedrom.js" | js.Build $options -}}
-    {{- $_ := $js.RelPermalink -}}
-    {{- dict "Link" $js.RelPermalink "Fingerprint" $fingerprint "Defer" true | dict "Scratch" .Scratch "Data" | partial "scratch/script.html" -}}
+    {{- dict "Resource" $js "Fingerprint" $fingerprint "Defer" true | dict "Scratch" .Scratch "Data" | partial "scratch/script.html" -}}
 {{- end -}}
 
 {{- if .Scratch.Get "enableTabs" -}}
@@ -234,8 +228,7 @@
         {{- $options = dict "minify" true | merge $options -}}
         {{- $options = dict "shims" $shims | merge $options -}}
         {{- $js := resources.Get "js/lib/aplayer.js" | js.Build $options -}}
-        {{- $_ := $js.RelPermalink -}}
-        {{- dict "Link" $js.RelPermalink "Fingerprint" $fingerprint "Defer" true | dict "Scratch" .Scratch "Data" | partial "scratch/script.html" -}}
+        {{- dict "Resource" $js "Fingerprint" $fingerprint "Defer" true | dict "Scratch" .Scratch "Data" | partial "scratch/script.html" -}}
     {{- end -}}
 {{- end -}}
 
@@ -256,8 +249,7 @@
     {{- $options = dict "minify" true | merge $options -}}
     {{- $options = dict "shims" $shims | merge $options -}}
     {{- $js := resources.Get "js/lib/cookieconsent.js" | js.Build $options -}}
-    {{- $_ := $js.RelPermalink -}}
-    {{- dict "Link" $js.RelPermalink "Fingerprint" $fingerprint "Defer" true | dict "Scratch" .Scratch "Data" | partial "scratch/script.html" -}}
+    {{- dict "Resource" $js "Fingerprint" $fingerprint "Defer" true | dict "Scratch" .Scratch "Data" | partial "scratch/script.html" -}}
 {{- end -}}
 
 {{- range $params.library.css -}}
@@ -309,8 +301,7 @@
     {{- $options = dict "sourceMap" "inline" | merge $options -}}
 {{- end -}}
 {{- $js := resources.Get "js/theme.ts" | js.Build $options -}}
-{{- $_ := $js.RelPermalink -}}
-{{- dict "Link" $js.RelPermalink "Fingerprint" $fingerprint "Defer" true | dict "Scratch" .Scratch "Data" | partial "scratch/script.html" -}}
+{{- dict "Resource" $js "Fingerprint" $fingerprint "Defer" true | dict "Scratch" .Scratch "Data" | partial "scratch/script.html" -}}
 
 {{- with .Scratch.Get "scriptArr" -}}
 {{- delimit . "\n" | dict "Content" | dict "Scratch" $.Scratch "Data" | partial "scratch/script.html" -}}

--- a/layouts/_partials/comment.html
+++ b/layouts/_partials/comment.html
@@ -31,8 +31,7 @@
             {{- end -}}
             {{- $options := dict "targetPath" "js/gitalk.min.js" "minify" true -}}
             {{- $js := resources.Get "js/lib/gitalk.js" | js.Build $options -}}
-            {{- $_ := $js.RelPermalink -}}
-            {{- dict "Link" $js.RelPermalink "Fingerprint" $fingerprint "Defer" true | dict "Scratch" .Scratch "Data" | partial "scratch/commentScript.html" -}}
+            {{- dict "Resource" $js "Fingerprint" $fingerprint "Defer" true | dict "Scratch" .Scratch "Data" | partial "scratch/commentScript.html" -}}
             <noscript>
                 Please enable JavaScript to view the comments powered by <a href="https://github.com/gitalk/gitalk"></a>Gitalk</a>.
             </noscript>
@@ -66,8 +65,7 @@
             {{- $options = dict "targetPath" "js/valine.min.js" | merge $options -}}
             {{- $options = dict "minify" true | merge $options -}}
             {{- $js := resources.Get "js/lib/valine.js" | js.Build $options -}}
-            {{- $_ := $js.RelPermalink -}}
-            {{- dict "Link" $js.RelPermalink "Fingerprint" $fingerprint "Defer" true | dict "Scratch" .Scratch "Data" | partial "scratch/commentScript.html" -}}
+            {{- dict "Resource" $js "Fingerprint" $fingerprint "Defer" true | dict "Scratch" .Scratch "Data" | partial "scratch/commentScript.html" -}}
             <noscript>
                 Please enable JavaScript to view the comments powered by <a href="https://valine.js.org/">Valine</a>.
             </noscript>
@@ -124,8 +122,7 @@
             {{- $options = dict "targetPath" "js/waline.min.js" | merge $options -}}
             {{- $options = dict "minify" true | merge $options -}}
             {{- $js := resources.Get "js/lib/waline.js" | js.Build $options -}}
-            {{- $_ := $js.RelPermalink -}}
-            {{- dict "Link" $js.RelPermalink "Fingerprint" $fingerprint "Defer" true | dict "Scratch" .Scratch "Data" | partial "scratch/commentScript.html" -}}
+            {{- dict "Resource" $js "Fingerprint" $fingerprint "Defer" true | dict "Scratch" .Scratch "Data" | partial "scratch/commentScript.html" -}}
             <noscript>
                 Please enable JavaScript to view the comments powered by <a href="https://waline.js.org/">Waline</a>.
             </noscript>
@@ -200,8 +197,7 @@
             {{- $commentConfig = $utterances.darkTheme | default "github-dark" | dict "darkTheme" | dict "utterances" | merge $commentConfig -}}
             {{- $options := dict "targetPath" "js/utterances.min.js" "minify" true -}}
             {{- $js := resources.Get "js/lib/utterances.js" | js.Build $options -}}
-            {{- $_ := $js.RelPermalink -}}
-            {{- dict "Link" $js.RelPermalink "Fingerprint" $fingerprint "Defer" true | dict "Scratch" .Scratch "Data" | partial "scratch/commentScript.html" -}}
+            {{- dict "Resource" $js "Fingerprint" $fingerprint "Defer" true | dict "Scratch" .Scratch "Data" | partial "scratch/commentScript.html" -}}
             <noscript>
                 Please enable JavaScript to view the comments powered by <a href="https://utteranc.es/">Utterances</a>.
             </noscript>
@@ -224,7 +220,7 @@
             {{- end -}}
             {{- $options = dict "shims" $shims | merge $options -}}
             {{- $js := resources.Get "js/lib/twikoo.js" | js.Build $options -}}
-            {{- dict "Link" $js.RelPermalink "Fingerprint" $fingerprint "Defer" true | dict "Scratch" .Scratch "Data" | partial "scratch/commentScript.html" -}}
+            {{- dict "Resource" $js "Fingerprint" $fingerprint "Defer" true | dict "Scratch" .Scratch "Data" | partial "scratch/commentScript.html" -}}
             {{- $commentConfig = dict "el" "#twikoo" "envId" $twikoo.envId | dict "twikoo" | merge $commentConfig -}}
             {{- $commentConfig = dict "lang" .Lang | dict "twikoo" | merge $commentConfig -}}
             {{- with $twikoo.region -}}
@@ -280,8 +276,7 @@
                 {{- end -}}
                 {{- $options := dict "targetPath" "js/vssue.min.js" "minify" true -}}
                 {{- $js := resources.Get "js/lib/vssue.js" | js.Build $options -}}
-                {{- $_ := $js.RelPermalink -}}
-                {{- dict "Link" $js.RelPermalink "Fingerprint" $fingerprint "Defer" true | dict "Scratch" .Scratch "Data" | partial "scratch/commentScript.html" -}}
+                {{- dict "Resource" $js "Fingerprint" $fingerprint "Defer" true | dict "Scratch" .Scratch "Data" | partial "scratch/commentScript.html" -}}
             <noscript>
                 Please enable JavaScript to view the comments powered by <a href="https://vssue.js.org/">Vssue</a>.
             </noscript>
@@ -303,8 +298,7 @@
             {{- end -}}
             {{- $options := dict "targetPath" "js/remark42.min.js" "minify" true -}}
             {{- $js := resources.Get "js/lib/remark42.js" | js.Build $options -}}
-            {{- $_ := $js.RelPermalink -}}
-            {{- dict "Link" $js.RelPermalink "Fingerprint" $fingerprint "Defer" true | dict "Scratch" .Scratch "Data" | partial "scratch/commentScript.html" -}}
+            {{- dict "Resource" $js "Fingerprint" $fingerprint "Defer" true | dict "Scratch" .Scratch "Data" | partial "scratch/commentScript.html" -}}
             <noscript>
                 Please enable JavaScript to view the comments powered by <a href="https://remark42.com/">Remark42</a>.
             </noscript>
@@ -329,8 +323,7 @@
             {{- $commentConfig = $giscus.dataLoading | default "lazy" | dict "dataLoading" | dict "giscus" | merge $commentConfig -}}
             {{- $options := dict "targetPath" "js/giscus.min.js" "minify" true -}}
             {{- $js := resources.Get "js/lib/giscus.js" | js.Build $options -}}
-            {{- $_ := $js.RelPermalink -}}
-            {{- dict "Link" $js.RelPermalink "Fingerprint" $fingerprint "Defer" true | dict "Scratch" .Scratch "Data" | partial "scratch/commentScript.html" -}}
+            {{- dict "Resource" $js "Fingerprint" $fingerprint "Defer" true | dict "Scratch" .Scratch "Data" | partial "scratch/commentScript.html" -}}
             <noscript>
                 Please enable JavaScript to view the comments powered by <a href="https://giscus.app/">giscus</a>.
             </noscript>
@@ -366,7 +359,7 @@
             {{- $options = dict "minify" true | merge $options -}}
             {{- $options = dict "shims" $shims | merge $options -}}
             {{- $js := resources.Get "js/lib/artalk.js" | js.Build $options -}}
-            {{- dict "Link" $js.RelPermalink "Fingerprint" $fingerprint "Defer" true | dict "Scratch" .Scratch "Data" | partial "scratch/commentScript.html" -}}            
+            {{- dict "Resource" $js "Fingerprint" $fingerprint "Defer" true | dict "Scratch" .Scratch "Data" | partial "scratch/commentScript.html" -}}
         {{- end -}}
     </div>
 {{- end -}}

--- a/layouts/_partials/head/link.html
+++ b/layouts/_partials/head/link.html
@@ -40,11 +40,11 @@
 {{- end -}}
 
 {{/*  tailwind.css  */}}
-{{ $style := dict "Source" "css/main.css" "Minify" true }}
+{{ $style := dict "Source" "css/main.css" "Minify" true "Fingerprint" $fingerprint }}
 {{- partial "plugin/style.html" $style -}}
 
 {{- /* style.min.css */ -}}
-{{- $style := dict "Source" "css/style.scss" -}}
+{{- $style := dict "Source" "css/style.scss" "Fingerprint" $fingerprint -}}
 {{- $options := dict "targetPath" "css/style.min.css" "enableSourceMap" true -}}
 {{- $style = dict "Context" . "ToCSS" $options | merge $style -}}
 {{- partial "plugin/style.html" $style -}}

--- a/layouts/_partials/plugin/script.html
+++ b/layouts/_partials/plugin/script.html
@@ -7,9 +7,13 @@
 {{- else -}}
   {{- $src := .Source -}}
   {{- $integrity := .Integrity -}}
-  {{- if $src -}}
+  {{- $resource := .Resource -}}
+  {{- if and (not $resource) $src -}}
     {{- if (urls.Parse $src).Host | not -}}
-      {{- $resource := resources.Get $src -}}
+      {{- $resource = resources.Get $src -}}
+    {{- end -}}
+  {{- end -}}
+  {{- if $resource -}}
       {{- with .Template -}}
         {{- $resource = $resource | resources.ExecuteAsTemplate . $.Context -}}
       {{- end -}}
@@ -21,7 +25,6 @@
         {{- $integrity = $resource.Data.Integrity -}}
       {{- end -}}
       {{- $src = $resource.RelPermalink -}}
-    {{- end -}}
   {{- end -}}
   {{- with .Link -}}
     {{- $src = . -}}

--- a/layouts/_partials/plugin/style.html
+++ b/layouts/_partials/plugin/style.html
@@ -3,8 +3,8 @@
 {{- else -}}
     {{- $href := .Source -}}
     {{- $integrity := .Integrity -}}
-    {{- $resource := 0 -}}
-    {{- if $href | and (not (urls.Parse $href).Host) -}}
+    {{- $resource := .Resource -}}
+    {{- if and (not $resource) $href (not (urls.Parse $href).Host) -}}
         {{- $resource = resources.Get $href -}}
     {{- end -}}
     {{- with .Content -}}


### PR DESCRIPTION
## Summary
- allow asset partials to fingerprint already-built Hugo resources
- restore fingerprinting for core CSS assets when `params.fingerprint` is configured
- pass built JS resources through the fingerprinting path instead of pre-resolved links

## Verification
- `HUGO_PARAMS_FINGERPRINT=sha256 hugo --source exampleSite --themesDir ../.. --environment production --destination /private/tmp/doit-fingerprint-check --cleanDestinationDir`
- `HUGO_PARAMS_FINGERPRINT= hugo --source exampleSite --themesDir ../.. --environment production --destination /private/tmp/doit-no-fingerprint-check --cleanDestinationDir`
- `git diff --check`

Fixes #1628