### PR TITLE
Update Plausible analytics snippet

### DIFF
--- a/exampleSite/config/_default/params.toml
+++ b/exampleSite/config/_default/params.toml
@@ -602,8 +602,13 @@ bundle = false
     data_domains = ""
   # Plausible Analytics
   [analytics.plausible]
+    # legacy tracking snippet, used when script is empty
+    # 旧版跟踪代码，在 script 为空时使用
     data_domain = ""
     src = ""
+    # tracking script for plausible.init(...)
+    # plausible.init(...) 跟踪脚本
+    script = ""
   # Cloudflare Analytics
   [analytics.cloudflare]
     token = ""

--- a/exampleSite/content/posts/theme-documentation-basics/index.en.md
+++ b/exampleSite/content/posts/theme-documentation-basics/index.en.md
@@ -823,8 +823,11 @@ Please open the code block below to view the complete sample configuration {{< f
       data_domains = ""
     # {{< version 0.2.13 >}} Plausible Analytics
     [params.analytics.plausible]
+      # legacy tracking snippet, used when script is empty
       data_domain = ""
       src = ""
+      # tracking script for plausible.init(...)
+      script = ""
     # {{< version 0.2.14 >}} Cloudflare Analytics
     [params.analytics.cloudflare]
       token = ""

--- a/exampleSite/content/posts/theme-documentation-basics/index.zh-cn.md
+++ b/exampleSite/content/posts/theme-documentation-basics/index.zh-cn.md
@@ -826,8 +826,11 @@ optimizeImages = true
       data_domains = ""
     # {{< version 0.2.13 >}} Plausible Analytics
     [params.analytics.plausible]
+      # 旧版跟踪代码，在 script 为空时使用
       data_domain = ""
       src = ""
+      # plausible.init(...) 跟踪脚本
+      script = ""
     # {{< version 0.2.14 >}} Cloudflare Analytics
     [params.analytics.cloudflare]
       token = ""

--- a/layouts/_partials/plugin/analytics-plausible.html
+++ b/layouts/_partials/plugin/analytics-plausible.html
@@ -1,0 +1,10 @@
+{{- $analytics := .Scratch.Get "analytics" | default dict -}}
+
+{{- if and $analytics.enable $analytics.plausible.script -}}
+    {{- with $analytics.plausible.src -}}
+        <script async defer src="{{ . }}"></script>
+        <script>
+            {{- $analytics.plausible.script | safeJS -}}
+        </script>
+    {{- end -}}
+{{- end -}}

--- a/layouts/_partials/plugin/analytics.html
+++ b/layouts/_partials/plugin/analytics.html
@@ -39,8 +39,12 @@
     {{- end -}}
 
     {{- /* Plausible Analytics */ -}}
-    {{- with $analytics.plausible.data_domain -}}
-        <script async defer data-domain="{{ . }}" src="{{ $analytics.plausible.src }}"></script>
+    {{- if not $analytics.plausible.script -}}
+        {{- with $analytics.plausible.src -}}
+            {{- with $analytics.plausible.data_domain -}}
+                <script async defer data-domain="{{ . }}" src="{{ $analytics.plausible.src }}"></script>
+            {{- end -}}
+        {{- end -}}
     {{- end -}}
 
     {{- /* Cloudflare Analytics */ -}}

--- a/layouts/baseof.html
+++ b/layouts/baseof.html
@@ -22,6 +22,7 @@
     {{- partial "head/meta.html" . -}}
     {{- partial "head/link.html" . -}}
     {{- partial "head/seo.html" . -}}
+    {{- partial "plugin/analytics-plausible.html" . -}}
 </head>
 
 {{/*  


### PR DESCRIPTION
## Summary
- render analytics snippets in the document head
- support Plausible's updated script flow with an optional inline init script
- keep the existing data_domain-based legacy Plausible snippet as a fallback
- document the new Plausible script config in example settings and docs

Fixes #1629

## Test
- npm run build:preview
- npm run build