### PR TITLE
feat: include featured image in LightGallery when opted in via featuredImageLightgallery

### DIFF
--- a/assets/js/theme.ts
+++ b/assets/js/theme.ts
@@ -568,7 +568,8 @@ function initDetails() {
 function initLightGallery() {
   if (window.config.lightGallery) {
     lightGallery(
-      document.getElementById("content"),
+      document.querySelector("article.page.single") ||
+        document.getElementById("content"),
       window.config.lightGallery,
     );
   }

--- a/exampleSite/config/_default/params.toml
+++ b/exampleSite/config/_default/params.toml
@@ -146,6 +146,9 @@ bundle = false
   # whether to enable lightgallery
   # 是否使用 lightgallery
   lightgallery = false
+  # whether to include featured image in lightgallery (requires lightgallery = true)
+  # 是否将特色图片包含在 lightgallery 中（需要 lightgallery = true）
+  # featuredImageLightgallery = false
   # whether to enable the ruby extended syntax
   # 是否使用 ruby 扩展语法
   ruby = true

--- a/layouts/posts/single.html
+++ b/layouts/posts/single.html
@@ -170,10 +170,13 @@
                     (dict "Process" "resize 1200x webp q75" "descriptor" "1200w")
                     (dict "Process" "resize 1600x webp q75" "descriptor" "1600w") 
                 -}}
+                {{- $lightgallery := $.Params.lightgallery | default (site.Params.page.lightgallery | default false) -}}
+                {{- $featuredImageLG := $.Params.featuredImageLightgallery | default (site.Params.page.featuredImageLightgallery | default false) -}}
+                {{- $linked := and $lightgallery $featuredImageLG -}}
                 {{- if page.Params.featuredImageCaption -}}
                     <figure>
                 {{- end -}}
-                {{- dict "Src" . "Title" $.Description "Resources" $.Resources "Loading" "eager" "OptimConfig" $optim | partial "plugin/image.html" -}}
+                {{- dict "Src" . "Title" $.Description "Resources" $.Resources "Loading" "eager" "OptimConfig" $optim "Linked" $linked "Caption" ($.Params.featuredImageCaption | default "") | partial "plugin/image.html" -}}
                 {{- if page.Params.featuredImageCaption -}}
                 {{- with page.Params.featuredImageCaption | default "" -}}
                     <figcaption>{{ . }}</figcaption>


### PR DESCRIPTION
Add featuredImageLightgallery param (front matter + site-level) to control whether the featured image participates in the lightbox gallery. 
Defaults to false, requiring explicit opt-in.
    
Changes:
- Pass Linked and Caption to featured image partial call, gated on both lightgallery and featuredImageLightgallery being true
- Widen LightGallery init container to article.page.single so the featured image (outside #content) is also scanned
- Add commented-out param to example site config as documentation

This closes #1654.