### PR TITLE
fix: add image-caption class to featuredImageCaption figcaption

### DIFF
--- a/assets/css/_page/_single.scss
+++ b/assets/css/_page/_single.scss
@@ -43,6 +43,21 @@
       margin: 0 auto;
       overflow: hidden;
     }
+
+    figure {
+      margin: 0;
+      text-align: center;
+
+      .image-caption:not(:empty) {
+        min-width: 20%;
+        max-width: 80%;
+        display: inline-block;
+        padding: 0.5rem;
+        margin: 0 auto;
+        font-size: 0.875rem;
+        color: #969696;
+      }
+    }
   }
 
   .content {

--- a/layouts/posts/single.html
+++ b/layouts/posts/single.html
@@ -176,7 +176,7 @@
                 {{- dict "Src" . "Title" $.Description "Resources" $.Resources "Loading" "eager" "OptimConfig" $optim | partial "plugin/image.html" -}}
                 {{- if page.Params.featuredImageCaption -}}
                 {{- with page.Params.featuredImageCaption | default "" -}}
-                    <figcaption>{{ . }}</figcaption>
+                    <figcaption class="image-caption">{{ . | safeHTML }}</figcaption>
                 {{- end -}}
                     </figure>
                 {{- end -}}


### PR DESCRIPTION
The featured image caption was rendered as a bare `<figcaption>` without the `image-caption` CSS class, causing it to miss all caption styling (font-size, color, padding, alignment) that the image shortcode and markdown render hook captions receive.

Add `class="image-caption"` and pipe through `safeHTML` to match the pattern used in `_shortcodes/image.html` and `_markup/render-image.html`. Add scoped caption styles to `.featured-image` in `_single.scss` since the existing rules are nested under `.content` and don't reach the featured image container.

This closes #1656.