### PR TITLE
feat: add Comentario as comment system

### DIFF
--- a/exampleSite/config/_default/params.toml
+++ b/exampleSite/config/_default/params.toml
@@ -422,6 +422,22 @@ bundle = false
     # Commento comment 评论系统设置 (https://commento.io/)
     [page.comment.commento]
       enable = false
+    # Comentario comment config (https://comentario.app/)
+    [page.comment.comentario]
+      enable = false
+      host = ""
+      script = ""
+      # Defaults to the page relative permalink.
+      pageId = ""
+      # Optional domain ID. Leave empty to let Comentario detect by host.
+      domainId = ""
+      cssOverride = ""
+      noFonts = true
+      autoInit = true
+      autoNonInteractiveSso = false
+      maxLevel = 10
+      liveUpdate = true
+      hideFooter = false
     # Utterances comment config (https://utteranc.es/)
     # Utterances comment 评论系统设置 (https://utteranc.es/)
     [page.comment.utterances]

--- a/exampleSite/content/posts/theme-documentation-basics/index.en.md
+++ b/exampleSite/content/posts/theme-documentation-basics/index.en.md
@@ -664,6 +664,22 @@ Please open the code block below to view the complete sample configuration {{< f
       # {{< version 0.2.0 >}} {{< link "https://commento.io/" "Commento" >}} comment config
       [params.page.comment.commento]
         enable = false
+      # {{< version 0.4.0 >}} {{< link "https://comentario.app/" "Comentario" >}} comment config
+      [params.page.comment.comentario]
+        enable = false
+        host = ""
+        script = ""
+        # Defaults to the page relative permalink.
+        pageId = ""
+        # Optional domain ID. Leave empty to let Comentario detect by host.
+        domainId = ""
+        cssOverride = ""
+        noFonts = true
+        autoInit = true
+        autoNonInteractiveSso = false
+        maxLevel = 10
+        liveUpdate = true
+        hideFooter = false
       # {{< version 0.2.5 >}} {{< link "https://utteranc.es/" "Utterances" >}} comment config
       [params.page.comment.utterances]
         enable = false

--- a/exampleSite/content/posts/theme-documentation-basics/index.zh-cn.md
+++ b/exampleSite/content/posts/theme-documentation-basics/index.zh-cn.md
@@ -667,6 +667,22 @@ optimizeImages = true
       # {{< version 0.2.0 >}} {{< link "https://commento.io/" "Commento" >}} 评论系统设置
       [params.page.comment.commento]
         enable = false
+      # {{< version 0.4.0 >}} {{< link "https://comentario.app/" "Comentario" >}} 评论系统设置
+      [params.page.comment.comentario]
+        enable = false
+        host = ""
+        script = ""
+        # 默认为页面相对永久链接。
+        pageId = ""
+        # 可选 domain ID。留空可让 Comentario 按主机名自动识别。
+        domainId = ""
+        cssOverride = ""
+        noFonts = true
+        autoInit = true
+        autoNonInteractiveSso = false
+        maxLevel = 10
+        liveUpdate = true
+        hideFooter = false
       # {{< version 0.2.5 >}} {{< link "https://utteranc.es/" "Utterances" >}} 评论系统设置
       [params.page.comment.utterances]
         enable = false

--- a/layouts/_partials/comment.html
+++ b/layouts/_partials/comment.html
@@ -186,6 +186,55 @@
             </noscript>
         {{- end -}}
 
+        {{- /* Comentario Comment System */ -}}
+        {{- $comentario := $comment.comentario | default dict -}}
+        {{- if $comentario.enable -}}
+            {{- $host := $comentario.host | default $comentario.serverURL -}}
+            {{- with $host -}}
+                {{- $pageId := $comentario.pageId | default $.RelPermalink -}}
+                {{- $attr := printf `lang="%v" page-id="%v"` $.Lang $pageId -}}
+                {{- with $comentario.domainId -}}
+                    {{- $attr = printf `%v domain-id="%v"` $attr . -}}
+                {{- end -}}
+                {{- with $comentario.cssOverride -}}
+                    {{- $attr = printf `%v css-override="%v"` $attr . -}}
+                {{- end -}}
+                {{- if isset $comentario "nofonts" -}}
+                    {{- $attr = printf `%v no-fonts="%v"` $attr $comentario.noFonts -}}
+                {{- end -}}
+                {{- if isset $comentario "autoinit" -}}
+                    {{- $attr = printf `%v auto-init="%v"` $attr $comentario.autoInit -}}
+                {{- end -}}
+                {{- if isset $comentario "autononinteractivesso" -}}
+                    {{- $attr = printf `%v auto-non-interactive-sso="%v"` $attr $comentario.autoNonInteractiveSso -}}
+                {{- end -}}
+                {{- with $comentario.maxLevel -}}
+                    {{- $attr = printf `%v max-level="%v"` $attr . -}}
+                {{- end -}}
+                {{- if isset $comentario "liveupdate" -}}
+                    {{- $attr = printf `%v live-update="%v"` $attr $comentario.liveUpdate -}}
+                {{- end -}}
+                {{- if $comentario.hideFooter -}}
+                    <style>
+                        comentario-comments .comentario-footer,
+                        comentario-comments .footer {
+                            display: none !important;
+                        }
+                    </style>
+                {{- end -}}
+                <comentario-comments {{ $attr | safeHTMLAttr }}></comentario-comments>
+                {{- $script := $comentario.script | default (printf "%v/comentario.js" .) -}}
+                {{- if and $script ((urls.Parse $script).Host | not) -}}
+                    {{- dict "Link" $script "Defer" true | dict "Scratch" $.Scratch "Data" | partial "scratch/commentScript.html" -}}
+                {{- else -}}
+                    {{- dict "Source" $script "Defer" true | dict "Scratch" $.Scratch "Data" | partial "scratch/commentScript.html" -}}
+                {{- end -}}
+                <noscript>
+                    Please enable JavaScript to view the comments.
+                </noscript>
+            {{- end -}}
+        {{- end -}}
+
         {{- /* Utterances Comment System */ -}}
         {{- $utterances := $comment.utterances | default dict -}}
         {{- if $utterances.enable -}}


### PR DESCRIPTION
## Summary
- add Comentario integration to the comment partial with support for host, script, domain/page IDs, CSS override, and runtime flags
- support both local (`/comentario.js`) and absolute script URLs for embed loading
- add `page.comment.comentario.hideFooter` option and document all Comentario settings in example config/docs (EN + ZH)

## Test plan
- [x] Render template paths locally via Hugo in site integration
- [ ] Run DoIt example site build locally (`hugo --source exampleSite`) *(blocked by local Hugo compatibility: `.Site.Language.Locale` not available in this environment)*
- [x] Verify generated branch diff only touches Comentario support + docs

Example site: https://ashpex.net/2026/05/give-my-thinkpad-a-new-life/

Made by my trustworthy cursor